### PR TITLE
Add consumer docs and skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @denny-il/drizzle-pg-utils
 ### Query Example (Select + Update)
 
 ```typescript
-import { eq, sql } from 'drizzle-orm'
+import { eq, gte } from 'drizzle-orm'
 import { jsonb, pgTable, serial, text } from 'drizzle-orm/pg-core'
 import { json } from '@denny-il/drizzle-pg-utils'
 
@@ -50,6 +50,8 @@ await db
     // without merging the entire object in application code.
     profile: json.setPipe(
       users.profile,
+      // Initialize the optional branch before writing inside it.
+      (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
       // Set theme to 'dark'.
       (s) => s.user.preferences.theme.$set('dark'),
       // Set first value in tags array to 'intro'.
@@ -67,15 +69,26 @@ await db
 - Build, merge, coalesce, and modify arrays with typed SQL helpers.
 
 ```typescript
+import { eq } from 'drizzle-orm'
 import { json } from '@denny-il/drizzle-pg-utils'
 
 // Access nested properties with type safety
 const accessor = json.access(users.profile)
-const theme = accessor.user.preferences.theme.$value
+const rows = await db
+  .select({
+    id: users.id,
+    theme: accessor.user.preferences.theme.$value,
+  })
+  .from(users)
+  .where(eq(accessor.user.preferences.theme.$value, 'dark'))
 
 // Update values at specific paths
-const setter = json.set(users.profile)
-const updated = setter.user.name.$set('New Name')
+await db
+  .update(users)
+  .set({
+    profile: json.set(users.profile).user.name.$set('New Name'),
+  })
+  .where(eq(users.id, rows[0]!.id))
 ```
 
 ### Temporal Utilities
@@ -91,6 +104,21 @@ const events = pgTable('events', {
   scheduledAt: timestamp.column('scheduled_at'),
   createdAt: timestampz.column('created_at'),
 })
+
+await db.insert(events).values({
+  scheduledAt: Temporal.PlainDateTime.from('2026-03-15T09:30:00'),
+  createdAt: Temporal.Instant.from('2026-03-15T08:30:00Z'),
+})
+
+const upcoming = await db
+  .select({ scheduledAt: events.scheduledAt })
+  .from(events)
+  .where(
+    gte(
+      events.scheduledAt,
+      Temporal.PlainDateTime.from('2026-03-01T00:00:00'),
+    ),
+  )
 ```
 
 See `docs/temporal.md` for setup choices, runtime behavior, and examples.
@@ -99,6 +127,12 @@ See `docs/temporal.md` for setup choices, runtime behavior, and examples.
 
 - **[JSON Utilities](./docs/json.md)** - Complete guide to JSON operations
 - **[Temporal Utilities](./docs/temporal.md)** - Working with PostgreSQL date/time types using Temporal API
+
+## Agent Skills
+
+This repository includes an agent skill for library-consumer usage examples and troubleshooting:
+
+- **[drizzle-pg-utils](./skills/drizzle-pg-utils/SKILL.md)** - JSONB and Temporal helper guidance with query-focused examples
 
 ## License
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -11,31 +11,40 @@ The JSON helpers work with both JSONB columns and ad hoc SQL expressions typed a
 ```typescript
 const profile = json.access(users.profile)
 
-const theme = profile.user.preferences.theme.$value
-const themeText = profile.user.preferences.theme.$text
-const firstTag = profile.user.preferences.tags['0'].$value
+const rows = await db
+  .select({
+    theme: profile.user.preferences.theme.$value,
+    themeText: profile.user.preferences.theme.$text,
+    firstTag: profile.user.preferences.tags['0'].$value,
+  })
+  .from(users)
 ```
 
 ### Atomic multi-step updates
 
 ```typescript
-const updatedProfile = json.setPipe(
-  users.profile,
-  (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
-  (s) => s.user.preferences.theme.$set('dark'),
-  (s) => s.user.preferences.tags['0'].$set('intro'),
-)
+await db.update(users).set({
+  profile: json.setPipe(
+    users.profile,
+    (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
+    (s) => s.user.preferences.theme.$set('dark'),
+    (s) => s.user.preferences.tags['0'].$set('intro'),
+  ),
+})
 ```
 
 ### Build and merge JSONB in SQL
 
 ```typescript
-const payload = json.build({
-  source: 'api',
-  tags: ['typescript', 'drizzle'],
+await db.update(users).set({
+  profile: json.merge(
+    users.profile,
+    json.build({
+      source: 'api',
+      tags: ['typescript', 'drizzle'],
+    }),
+  ),
 })
-
-const merged = json.merge(users.profile, payload)
 ```
 
 ## Choose an Import Style
@@ -59,7 +68,7 @@ npm install @denny-il/drizzle-pg-utils
 This example uses the root namespace import for consistency.
 
 ```typescript
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { jsonb, pgTable, serial, text } from 'drizzle-orm/pg-core'
 import { json } from '@denny-il/drizzle-pg-utils'
 
@@ -96,6 +105,97 @@ await db
       (s) => s.user.preferences.theme.$set('dark'),
       (s) => s.user.preferences.tags['0'].$set('intro'),
       (s) => s.metadata.$default({}).lastLogin.$set('2026-03-15T09:30:00Z'),
+    ),
+  })
+  .where(eq(users.id, darkUsers[0]!.id))
+```
+
+## Query Examples
+
+The helpers are meant to live inside normal Drizzle queries, not as separate object transforms.
+
+### Select and filter by nested JSONB value
+
+```typescript
+import { eq } from 'drizzle-orm'
+
+const profile = json.access(users.profile)
+
+const darkUsers = await db
+  .select({
+    id: users.id,
+    name: profile.user.name.$text,
+    theme: profile.user.preferences.theme.$value,
+  })
+  .from(users)
+  .where(eq(profile.user.preferences.theme.$value, 'dark'))
+```
+
+### Update nested JSONB values atomically
+
+```typescript
+await db
+  .update(users)
+  .set({
+    profile: json.setPipe(
+      users.profile,
+      (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
+      (s) => s.user.name.$set('Jane'),
+      (s) => s.user.preferences.theme.$set('dark'),
+      (s) => s.user.preferences.tags['0'].$set('intro'),
+    ),
+  })
+  .where(eq(users.id, darkUsers[0]!.id))
+```
+
+This follows the same pattern tested with `jsonSetPipe(...)`: every step sees the JSONB expression produced by the previous step.
+
+### Use SQL values inside JSON updates
+
+```typescript
+import { eq, sql } from 'drizzle-orm'
+
+await db
+  .update(users)
+  .set({
+    profile: json.set(users.profile).metadata.$default({}).lastLogin.$set(
+      sql`now()::text`,
+    ),
+  })
+  .where(eq(users.id, darkUsers[0]!.id))
+```
+
+### Build and merge JSONB in an update
+
+```typescript
+import { eq, sql } from 'drizzle-orm'
+
+await db
+  .update(users)
+  .set({
+    profile: json.merge(
+      users.profile,
+      json.build({
+        metadata: {
+          importedAt: sql`now()::text`,
+          source: 'api',
+        },
+      }),
+    ),
+  })
+  .where(eq(users.id, darkUsers[0]!.id))
+```
+
+### Update JSON arrays
+
+```typescript
+const tags = json.access(users.profile).user.preferences.tags.$value
+
+await db
+  .update(users)
+  .set({
+    profile: json.set(users.profile).user.preferences.tags.$set(
+      json.arrayPush(tags, 'drizzle'),
     ),
   })
   .where(eq(users.id, darkUsers[0]!.id))
@@ -165,10 +265,17 @@ That behavior is useful, but it also means `merge(...)` is not a plain wrapper a
 `build(...)` accepts plain JS values, nested objects, arrays, and SQL expressions, then turns them into JSONB SQL.
 
 ```typescript
-const auditEntry = json.build({
-  at: sql`now()::text`,
-  actorId: users.id,
-  action: 'profile-updated',
+await db.update(users).set({
+  profile: json.merge(
+    users.profile,
+    json.build({
+      audit: {
+        at: sql`now()::text`,
+        actorId: users.id,
+        action: 'profile-updated',
+      },
+    }),
+  ),
 })
 ```
 
@@ -181,39 +288,49 @@ That makes it a good companion for `set(...)`, `setPipe(...)`, and `merge(...)`.
 ```typescript
 const profile = json.access(users.profile)
 
-const rows = await db.select({
-  name: profile.user.name.$text,
-  theme: profile.user.preferences.theme.$value,
-})
+const rows = await db
+  .select({
+    name: profile.user.name.$text,
+    theme: profile.user.preferences.theme.$value,
+  })
+  .from(users)
 ```
 
 ### Update one path
 
 ```typescript
-const nextProfile = json
-  .set(users.profile)
-  .user.preferences.theme.$set('dark')
+await db
+  .update(users)
+  .set({
+    profile: json.set(users.profile).user.preferences.theme.$set('dark'),
+  })
+  .where(eq(users.id, userId))
 ```
 
 ### Update several paths in one expression
 
 ```typescript
-const nextProfile = json.setPipe(
-  users.profile,
-  (s) => s.user.name.$set('Den'),
-  (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
-  (s) => s.user.preferences.tags['0'].$set('postgres'),
-)
+await db.update(users).set({
+  profile: json.setPipe(
+    users.profile,
+    (s) => s.user.name.$set('Den'),
+    (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
+    (s) => s.user.preferences.tags['0'].$set('postgres'),
+  ),
+})
 ```
 
 ### Merge overlay data
 
 ```typescript
-const overlay = json.build({
-  metadata: { importedAt: '2026-03-15T09:30:00Z' },
+await db.update(users).set({
+  profile: json.merge(
+    users.profile,
+    json.build({
+      metadata: { importedAt: '2026-03-15T09:30:00Z' },
+    }),
+  ),
 })
-
-const merged = json.merge(users.profile, overlay)
 ```
 
 ### Work with arrays
@@ -221,9 +338,11 @@ const merged = json.merge(users.profile, overlay)
 ```typescript
 const tags = json.access(users.profile).user.preferences.tags.$value
 
-const appended = json.arrayPush(tags, 'drizzle')
-const replaced = json.arraySet(tags, 0, 'typescript')
-const removed = json.arrayDelete(tags, -1)
+await db.update(users).set({
+  profile: json.set(users.profile).user.preferences.tags.$set(
+    json.arrayPush(tags, 'drizzle'),
+  ),
+})
 ```
 
 ## Minimal Reference

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -176,9 +176,9 @@ intervalstyle = 'iso_8601'
 
 These two helpers store strings and decode them back into Temporal values.
 
-- `yearMonth.constraints(...)` validates the `YYYY-MM` shape.
-- `monthDay.constraints(...)` validates the `MM-DD` shape.
-- The checks are useful, but they are still shape checks. Invalid calendar values can still fail later during Temporal parsing.
+- `yearMonth.constraints(...)` validates Temporal-compatible `YYYY-MM` and signed expanded-year strings like `+010000-01`.
+- `monthDay.constraints(...)` validates Temporal-compatible `MM-DD` strings, including month-specific day bounds like `02-29` and rejecting `02-30`.
+- The checks are designed to match `Temporal.PlainYearMonth.from(...)` and `Temporal.PlainMonthDay.from(...)` string parsing for ISO values.
 
 ## Factories and Serialization Defaults
 
@@ -202,6 +202,75 @@ const interval = createInterval(Temporal, { smallestUnit: 'millisecond' })
 ```
 
 Every `create*` helper returns the same helper shape as the prebound entrypoints.
+
+## Query Examples
+
+### Insert and select Temporal values
+
+```typescript
+await db.insert(events).values({
+  eventDate: Temporal.PlainDate.from('2023-07-25'),
+  startTime: Temporal.PlainTime.from('14:30:45.123'),
+  scheduledAt: Temporal.PlainDateTime.from('2023-07-25T14:30:45.123456'),
+  createdAt: Temporal.Instant.from('2023-07-25T18:30:45.123Z'),
+  duration: Temporal.Duration.from('PT2H30M15S'),
+})
+
+const [event] = await db
+  .select({
+    eventDate: events.eventDate,
+    startTime: events.startTime,
+    scheduledAt: events.scheduledAt,
+    createdAt: events.createdAt,
+    duration: events.duration,
+  })
+  .from(events)
+  .limit(1)
+```
+
+Selected values decode back to Temporal instances.
+
+### Filter with Temporal values
+
+```typescript
+import { gte } from 'drizzle-orm'
+
+const upcoming = await db
+  .select({ eventDate: events.eventDate })
+  .from(events)
+  .where(gte(events.eventDate, Temporal.PlainDate.from('2023-06-01')))
+```
+
+### Insert SQL expressions into Temporal columns
+
+```typescript
+import { sql } from 'drizzle-orm'
+
+await db.insert(events).values({
+  eventDate: sql`DATE '2023-07-25'`,
+  startTime: sql`TIME '14:30:45.123'`,
+  scheduledAt: sql`TIMESTAMP '2023-07-25 14:30:45.123456'`,
+  createdAt: sql`TIMESTAMP WITH TIME ZONE '2023-07-25 14:30:45.123-04'`,
+  duration: sql`INTERVAL '2 hours 30 minutes 15 seconds'`,
+})
+```
+
+### Use partial-date constraints in table definitions
+
+```typescript
+const reports = pgTable(
+  'reports',
+  {
+    id: serial('id').primaryKey(),
+    reportMonth: yearMonth.column('report_month'),
+    holidayDate: monthDay.column('holiday_date'),
+  },
+  (table) => ({
+    ...yearMonth.constraints(table.reportMonth),
+    ...monthDay.constraints(table.holidayDate),
+  }),
+)
+```
 
 ## Minimal Reference
 

--- a/skills/drizzle-pg-utils/SKILL.md
+++ b/skills/drizzle-pg-utils/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: drizzle-pg-utils
+description: Answer questions about the @denny-il/drizzle-pg-utils and help build complex JSON queries with Drizzle ORM, PostgreSQL JSONB helper usage and Temporal column mapping.
+---
+
+# Drizzle PG Utils
+
+Prefer practical Drizzle query examples using public package imports. Avoid `src/` internals. Show helpers inside `db.select(...)`, `db.update(...)`, and `db.insert(...)` when possible.
+
+## References
+
+- Read [references/json.md](references/json.md) for JSONB helpers: typed path access, `set`, `setPipe`, `$default`, SQL values, `build`, `merge`, array helpers, import styles, and query examples.
+- Read [references/temporal.md](references/temporal.md) for Temporal helpers: entrypoint choice, column mapping, factories, constraints, interval setup, SQL expressions, and query examples.

--- a/skills/drizzle-pg-utils/references/json.md
+++ b/skills/drizzle-pg-utils/references/json.md
@@ -1,0 +1,136 @@
+# JSON Helpers Reference
+
+## Imports
+
+```typescript
+import { json } from '@denny-il/drizzle-pg-utils'
+import { access, setPipe, merge } from '@denny-il/drizzle-pg-utils/json'
+import { jsonSet } from '@denny-il/drizzle-pg-utils/json/set'
+```
+
+There is no default export from `@denny-il/drizzle-pg-utils/json`.
+
+## Access
+
+```typescript
+import { eq } from 'drizzle-orm'
+
+const profile = json.access(users.profile)
+
+const rows = await db
+  .select({
+    name: profile.user.name.$text,
+    theme: profile.user.preferences.theme.$value,
+    firstTag: profile.user.preferences.tags[0].$value,
+  })
+  .from(users)
+  .where(eq(profile.user.preferences.theme.$value, 'dark'))
+```
+
+- `.$value` returns a typed JSONB SQL expression.
+- `.$text` returns a typed text SQL expression.
+- `.$path` is deprecated; use `.$value`.
+
+## Updates
+
+```typescript
+await db
+  .update(users)
+  .set({
+    profile: json.setPipe(
+      users.profile,
+      (s) => s.user.preferences.$default({ theme: 'light', tags: [] }),
+      (s) => s.user.preferences.theme.$set('dark'),
+      (s) => s.user.preferences.tags[0].$set('intro'),
+    ),
+  })
+  .where(eq(users.id, userId))
+```
+
+Use `.$default(...)` before writing through optional or nullable intermediate objects. Without it, PostgreSQL can leave the document unchanged when an earlier path segment is missing.
+
+## Helper Map
+
+| Helper | Use |
+| --- | --- |
+| `access(source)` | Typed JSON path extraction |
+| `set(source)` | One `jsonb_set(...)` update |
+| `setPipe(source, ...ops)` | Chain multiple JSON updates |
+| `build(value)` | Convert JS values and SQL snippets into JSONB SQL |
+| `coalesce(source, fallback)` | Treat SQL `NULL` and JSON `null` as empty |
+| `merge(left, right)` | Apply PostgreSQL JSONB `||` semantics with SQL `NULL` normalized |
+| `arrayPush(target, ...values)` | Append values to JSON array; nullish arrays become `[]` |
+| `arraySet(target, index, value)` | Replace array element; nullish arrays become `[]` |
+| `arrayDelete(target, index)` | Remove array element; nullish arrays become `[]` |
+
+## Build Example
+
+```typescript
+await db.update(users).set({
+  profile: json.merge(
+    users.profile,
+    json.build({
+      audit: {
+        at: sql`now()::text`,
+        actorId: users.id,
+        action: 'profile-updated',
+      },
+    }),
+  ),
+})
+```
+
+`json.build(...)` accepts plain JS values, nested objects, arrays, and SQL expressions.
+
+## Query Patterns
+
+### SQL value in JSON update
+
+```typescript
+import { eq, sql } from 'drizzle-orm'
+
+await db
+  .update(users)
+  .set({
+    profile: json.set(users.profile).metadata.$default({}).lastLogin.$set(
+      sql`now()::text`,
+    ),
+  })
+  .where(eq(users.id, userId))
+```
+
+### Merge built JSONB in update
+
+```typescript
+import { eq, sql } from 'drizzle-orm'
+
+await db
+  .update(users)
+  .set({
+    profile: json.merge(
+      users.profile,
+      json.build({
+        metadata: {
+          importedAt: sql`now()::text`,
+          source: 'api',
+        },
+      }),
+    ),
+  })
+  .where(eq(users.id, userId))
+```
+
+### Array update inside JSON document
+
+```typescript
+const tags = json.access(users.profile).user.preferences.tags.$value
+
+await db
+  .update(users)
+  .set({
+    profile: json.set(users.profile).user.preferences.tags.$set(
+      json.arrayPush(tags, 'drizzle'),
+    ),
+  })
+  .where(eq(users.id, userId))
+```

--- a/skills/drizzle-pg-utils/references/temporal.md
+++ b/skills/drizzle-pg-utils/references/temporal.md
@@ -1,0 +1,147 @@
+# Temporal Helpers Reference
+
+## Entrypoints
+
+| Import path | Use when |
+| --- | --- |
+| `@denny-il/drizzle-pg-utils/temporal` | Consumer wants explicit `create*` factories |
+| `@denny-il/drizzle-pg-utils/temporal/global` | Consumer has `globalThis.Temporal` or imports `temporal-polyfill/global` |
+| `@denny-il/drizzle-pg-utils/temporal/polyfill` | Consumer wants helpers bound to `temporal-polyfill` without globals |
+
+## Column Map
+
+| Helper | Temporal value | PostgreSQL type |
+| --- | --- | --- |
+| `timestamp` | `Temporal.PlainDateTime` | `timestamp[(precision)]` |
+| `timestampz` | `Temporal.Instant` | `timestamp[(precision)] with time zone` |
+| `plainDate` | `Temporal.PlainDate` | `date` |
+| `time` | `Temporal.PlainTime` | `time[(precision)]` |
+| `interval` | `Temporal.Duration` | `interval[fields][(precision)]` |
+| `yearMonth` | `Temporal.PlainYearMonth` | `text` |
+| `monthDay` | `Temporal.PlainMonthDay` | `text` |
+
+## Basic Example
+
+```typescript
+import 'temporal-polyfill/global'
+import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+import {
+  interval,
+  plainDate,
+  time,
+  timestamp,
+  timestampz,
+} from '@denny-il/drizzle-pg-utils/temporal/global'
+
+const events = pgTable('events', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  scheduledAt: timestamp.column('scheduled_at'),
+  createdAt: timestampz.column('created_at'),
+  eventDate: plainDate.column('event_date'),
+  startTime: time.column('start_time'),
+  duration: interval.column('duration'),
+})
+
+await db.insert(events).values({
+  eventDate: Temporal.PlainDate.from('2023-07-25'),
+  startTime: Temporal.PlainTime.from('14:30:45.123'),
+  scheduledAt: Temporal.PlainDateTime.from('2023-07-25T14:30:45.123456'),
+  createdAt: Temporal.Instant.from('2023-07-25T18:30:45.123Z'),
+  duration: Temporal.Duration.from('PT2H30M15S'),
+})
+
+const [event] = await db
+  .select({
+    eventDate: events.eventDate,
+    startTime: events.startTime,
+    scheduledAt: events.scheduledAt,
+    createdAt: events.createdAt,
+    duration: events.duration,
+  })
+  .from(events)
+  .limit(1)
+```
+
+## Factories
+
+```typescript
+import { Temporal } from 'temporal-polyfill'
+import {
+  createInterval,
+  createPlainDate,
+  createTime,
+  createTimestamp,
+  createTimestampz,
+} from '@denny-il/drizzle-pg-utils/temporal'
+
+const plainDate = createPlainDate(Temporal)
+const time = createTime(Temporal, { smallestUnit: 'millisecond' })
+const timestamp = createTimestamp(Temporal, { smallestUnit: 'millisecond' })
+const timestampz = createTimestampz(Temporal, { smallestUnit: 'millisecond' })
+const interval = createInterval(Temporal, { smallestUnit: 'millisecond' })
+```
+
+## Important Behavior
+
+`timestampz` maps to `Temporal.Instant`. Convert `Temporal.ZonedDateTime` with `.toInstant()` before writing.
+
+`interval` requires PostgreSQL ISO 8601 interval output:
+
+```sql
+SET intervalstyle = 'iso_8601';
+```
+
+`yearMonth.constraints(column, name?)` and `monthDay.constraints(column, name?)` add optional Temporal-compatible format checks for their text columns.
+
+- `yearMonth` accepts `YYYY-MM` and signed expanded-year strings like `+010000-01`, within Temporal's supported range.
+- `monthDay` accepts zero-padded `MM-DD` strings with month-specific day bounds, including `02-29` and rejecting values like `02-30`.
+
+```typescript
+const reports = pgTable(
+  'reports',
+  {
+    id: serial('id').primaryKey(),
+    reportMonth: yearMonth.column('report_month'),
+    holidayDate: monthDay.column('holiday_date'),
+  },
+  (table) => ({
+    ...yearMonth.constraints(table.reportMonth),
+    ...monthDay.constraints(table.holidayDate),
+  }),
+)
+```
+
+Pass a second argument to override the generated constraint name:
+
+```typescript
+yearMonth.constraints(table.reportMonth, 'reports_report_month_format')
+monthDay.constraints(table.holidayDate, 'reports_holiday_date_format')
+```
+
+## Query Patterns
+
+### Filter with Temporal values
+
+```typescript
+import { gte } from 'drizzle-orm'
+
+const upcoming = await db
+  .select({ eventDate: events.eventDate })
+  .from(events)
+  .where(gte(events.eventDate, Temporal.PlainDate.from('2023-06-01')))
+```
+
+### Insert SQL expressions
+
+```typescript
+import { sql } from 'drizzle-orm'
+
+await db.insert(events).values({
+  eventDate: sql`DATE '2023-07-25'`,
+  startTime: sql`TIME '14:30:45.123'`,
+  scheduledAt: sql`TIMESTAMP '2023-07-25 14:30:45.123456'`,
+  createdAt: sql`TIMESTAMP WITH TIME ZONE '2023-07-25 14:30:45.123-04'`,
+  duration: sql`INTERVAL '2 hours 30 minutes 15 seconds'`,
+})
+```


### PR DESCRIPTION
## Summary

- Expand README and docs with query-focused usage examples for JSONB and Temporal helpers.
- Add a consumer-facing `drizzle-pg-utils` agent skill with JSON and Temporal references.
- Document Temporal constraint behavior and examples.
