### PR TITLE
feat(json): index-friendly "contains" helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ await db
 
 ### JSON Utilities
 - Access nested JSONB paths with full TypeScript inference and no runtime schema.
+- Query JSONB containment with typed path traversal and full-column index-friendly SQL.
 - Update deep branches atomically with `set(...)` and `setPipe(...)`.
 - Build, merge, coalesce, and modify arrays with typed SQL helpers.
 
@@ -81,6 +82,16 @@ const rows = await db
   })
   .from(users)
   .where(eq(accessor.user.preferences.theme.$value, 'dark'))
+
+// Query JSONB containment while keeping the predicate rooted at users.profile
+const darkUsers = await db
+  .select({ id: users.id })
+  .from(users)
+  .where(
+    json
+      .contains(users.profile)
+      .user.preferences.$contains({ theme: 'dark' }),
+  )
 
 // Update values at specific paths
 await db

--- a/docs/json.md
+++ b/docs/json.md
@@ -210,12 +210,45 @@ await db
 | `setPipe(source, ...ops)` | Chain multiple JSON updates | Each step sees the previous result |
 | `build(value)` | Convert JS values and SQL snippets into JSONB SQL | Handles nested arrays and objects |
 | `coalesce(source, fallback)` | Replace SQL `NULL` and JSON `null` with a fallback | Useful before updates |
+| `contains(source)` | Typed JSONB containment builder | Use `.$contains(...)`; emits full-column index-friendly `source @> value` |
+| `contains(source, value)` | JSONB root containment predicate | Direct form for already-shaped containment values |
 | `merge(left, right)` | Apply PostgreSQL JSONB `||` semantics | SQL `NULL` is normalized to JSON `null` first |
 | `arrayPush(target, ...values)` | Append values to a JSON array | Nullish arrays become `[]` |
 | `arraySet(target, index, value)` | Replace an element at an index | Nullish arrays become `[]` |
 | `arrayDelete(target, index)` | Remove an element at an index | Nullish arrays become `[]` |
 
 ## Important Behavior
+
+### Containment keeps queries index-friendly
+
+Use `contains(...)` for JSONB `@>` predicates that should use a full-column GIN or `jsonb_path_ops` index.
+
+```typescript
+await db
+  .select({ id: users.id })
+  .from(users)
+  .where(
+    json
+      .contains(users.profile)
+      .user.preferences.$contains({ theme: 'dark' }),
+  )
+```
+
+That proxy form emits a root containment predicate:
+
+```sql
+profile @> '{"user":{"preferences":{"theme":"dark"}}}'::jsonb
+```
+
+The direct form is useful when you already have the full containment shape:
+
+```typescript
+json.contains(users.profile, {
+  user: { preferences: { theme: 'dark' } },
+})
+```
+
+Do not use `json.access(users.profile).user.preferences.$value @> ...` when you expect a full-column JSONB index to be used. That filters on `jsonb_extract_path(...)`, so it needs an expression index on the extracted path instead.
 
 ### Access is typed, but schema-free
 
@@ -355,6 +388,8 @@ await db.update(users).set({
 - `json.arraySet(source, index, value)`
 - `json.build(value)`
 - `json.coalesce(source, fallback)`
+- `json.contains(source)`
+- `json.contains(source, value)`
 - `json.merge(left, right)`
 - `json.set(source)`
 - `json.setPipe(source, ...operations)`
@@ -365,6 +400,7 @@ await db.update(users).set({
 - `arrayDelete`, `arrayPush`, `arraySet` from `@denny-il/drizzle-pg-utils/json`
 - `build` from `@denny-il/drizzle-pg-utils/json`
 - `coalesce` from `@denny-il/drizzle-pg-utils/json`
+- `contains` from `@denny-il/drizzle-pg-utils/json`
 - `merge` from `@denny-il/drizzle-pg-utils/json`
 - `set`, `setPipe` from `@denny-il/drizzle-pg-utils/json`
 
@@ -374,5 +410,6 @@ await db.update(users).set({
 - `@denny-il/drizzle-pg-utils/json/array`
 - `@denny-il/drizzle-pg-utils/json/build`
 - `@denny-il/drizzle-pg-utils/json/coalesce`
+- `@denny-il/drizzle-pg-utils/json/contains`
 - `@denny-il/drizzle-pg-utils/json/merge`
 - `@denny-il/drizzle-pg-utils/json/set`

--- a/skills/drizzle-pg-utils/references/json.md
+++ b/skills/drizzle-pg-utils/references/json.md
@@ -4,7 +4,7 @@
 
 ```typescript
 import { json } from '@denny-il/drizzle-pg-utils'
-import { access, setPipe, merge } from '@denny-il/drizzle-pg-utils/json'
+import { access, contains, setPipe, merge } from '@denny-il/drizzle-pg-utils/json'
 import { jsonSet } from '@denny-il/drizzle-pg-utils/json/set'
 ```
 
@@ -58,6 +58,8 @@ Use `.$default(...)` before writing through optional or nullable intermediate ob
 | `setPipe(source, ...ops)` | Chain multiple JSON updates |
 | `build(value)` | Convert JS values and SQL snippets into JSONB SQL |
 | `coalesce(source, fallback)` | Treat SQL `NULL` and JSON `null` as empty |
+| `contains(source)` | Typed JSONB containment builder; use `.$contains(...)` |
+| `contains(source, value)` | Direct JSONB root containment predicate |
 | `merge(left, right)` | Apply PostgreSQL JSONB `||` semantics with SQL `NULL` normalized |
 | `arrayPush(target, ...values)` | Append values to JSON array; nullish arrays become `[]` |
 | `arraySet(target, index, value)` | Replace array element; nullish arrays become `[]` |
@@ -83,6 +85,25 @@ await db.update(users).set({
 `json.build(...)` accepts plain JS values, nested objects, arrays, and SQL expressions.
 
 ## Query Patterns
+
+### Index-friendly JSONB containment
+
+```typescript
+await db
+  .select({ id: users.id })
+  .from(users)
+  .where(
+    contains(users.profile).user.preferences.$contains({ theme: 'dark' }),
+  )
+```
+
+This emits `profile @> ...`, so full-column GIN and `jsonb_path_ops` indexes can be used. Direct form is also available:
+
+```typescript
+contains(users.profile, {
+  user: { preferences: { theme: 'dark' } },
+})
+```
 
 ### SQL value in JSON update
 

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -6,5 +6,6 @@ export {
 } from './operations/array.ts'
 export { jsonBuild as build } from './operations/build.ts'
 export { jsonCoalesce as coalesce } from './operations/coalesce.ts'
+export { jsonContains as contains } from './operations/contains.ts'
 export { jsonMerge as merge } from './operations/merge.ts'
 export { jsonSet as set, jsonSetPipe as setPipe } from './operations/set.ts'

--- a/src/json/operations/contains.ts
+++ b/src/json/operations/contains.ts
@@ -1,0 +1,95 @@
+import { isSQLWrapper, type SQL, sql } from 'drizzle-orm'
+import type {
+  SQLJSONDenullify,
+  SQLJSONExtractType,
+  SQLJSONValue,
+} from '../common.ts'
+
+export type SQLJSONContainmentValue<Type> =
+  Type extends readonly (infer Element)[]
+    ? Array<SQLJSONContainmentValue<Element>>
+    : Type extends object
+      ? { [K in keyof Type]?: SQLJSONContainmentValue<Type[K]> }
+      : Type
+
+export type SQLJSONContains<
+  Source extends SQLJSONValue,
+  Type = SQLJSONExtractType<Source>,
+  ObjectType extends SQLJSONDenullify<Type> = SQLJSONDenullify<Type>,
+> = {
+  $contains(
+    value:
+      | SQLJSONContainmentValue<ObjectType>
+      | SQLJSONValue<SQLJSONContainmentValue<ObjectType>>,
+  ): SQL<boolean>
+} & (ObjectType extends readonly (infer Element)[]
+  ? {
+      [index: number]: SQLJSONContains<Source, Element>
+    }
+  : ObjectType extends object
+    ? {
+        [K in keyof ObjectType]-?: SQLJSONContains<Source, ObjectType[K]>
+      }
+    : {})
+
+export function jsonContains<Source extends SQLJSONValue>(
+  source: Source,
+): SQLJSONContains<Source>
+
+export function jsonContains<
+  Source extends SQLJSONValue,
+  SourceType extends SQLJSONExtractType<Source> = SQLJSONExtractType<Source>,
+>(
+  source: Source,
+  value:
+    | SQLJSONContainmentValue<SQLJSONDenullify<SourceType>>
+    | SQLJSONValue<SQLJSONContainmentValue<SQLJSONDenullify<SourceType>>>,
+): SQL<boolean>
+
+export function jsonContains<Source extends SQLJSONValue>(
+  source: Source,
+  ...args: [
+    value?: SQLJSONContainmentValue<SQLJSONExtractType<Source>> | SQLJSONValue,
+  ]
+): SQL<boolean> | SQLJSONContains<Source> {
+  function buildContains(value: SQLJSONContainmentValue<any> | SQLJSONValue) {
+    const containmentValue = isSQLWrapper(value)
+      ? value
+      : sql`${JSON.stringify(value)}::jsonb`
+
+    return sql<boolean>`${source} @> ${containmentValue}`
+  }
+
+  function wrapPath(path: string[], value: unknown) {
+    return path.reduceRight<unknown>(
+      (acc, segment) => ({ [segment]: acc }),
+      value,
+    )
+  }
+
+  function createProxy(path: string[] = []): SQLJSONContains<Source> {
+    return new Proxy(Object.create(null), {
+      get(_, property) {
+        if (typeof property === 'symbol')
+          throw new TypeError('Symbols are not supported in JSON paths')
+        if (property === '$contains') {
+          return (value: SQLJSONContainmentValue<any> | SQLJSONValue) => {
+            if (isSQLWrapper(value)) {
+              if (path.length > 0)
+                throw new Error(
+                  'SQL containment values are only supported at the root path',
+                )
+              return buildContains(value)
+            }
+            return buildContains(wrapPath(path, value))
+          }
+        }
+        return createProxy([...path, property])
+      },
+    }) as SQLJSONContains<Source>
+  }
+
+  if (args.length === 0) return createProxy()
+
+  return buildContains(args[0])
+}

--- a/tests/json/contains.test.ts
+++ b/tests/json/contains.test.ts
@@ -1,0 +1,121 @@
+import { type SQL, sql } from 'drizzle-orm'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { jsonBuild } from '../../src/json/operations/build.ts'
+import {
+  jsonContains,
+  type SQLJSONContains,
+} from '../../src/json/operations/contains.ts'
+import { dialect, table } from '../utils.ts'
+
+describe('JSON Contains', () => {
+  type JsonType = {
+    kind: 'alpha' | 'beta'
+    profile: {
+      email: string
+      status: 'active' | 'inactive'
+    }
+    tags: Array<{ name: string; weight: number }>
+  }
+
+  const jsonObjectSql = `'{"kind":"alpha","profile":{"email":"user@example.com","status":"active"},"tags":[{"name":"tag1","weight":1}]}'::jsonb`
+  const jsonObject = sql<JsonType>`${sql.raw(jsonObjectSql)}`
+
+  it('creates typed proxy containment helpers', () => {
+    const contains = jsonContains(jsonObject)
+
+    expect(contains).toBeDefined()
+    expectTypeOf(contains).toEqualTypeOf<SQLJSONContains<SQL<JsonType>>>()
+    expectTypeOf(
+      contains.profile.email.$contains('user@example.com'),
+    ).toEqualTypeOf<SQL<boolean>>()
+  })
+
+  it('generates root containment SQL for nested object values', () => {
+    const result = jsonContains(jsonObject, {
+      profile: { email: 'user@example.com' },
+    })
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([
+      JSON.stringify({ profile: { email: 'user@example.com' } }),
+    ])
+    expect(query.sql).toBe(`${jsonObjectSql} @> $1::jsonb`)
+    expectTypeOf(result).toEqualTypeOf<SQL<boolean>>()
+  })
+
+  it('generates root containment SQL from nested proxy paths', () => {
+    const result = jsonContains(jsonObject).profile.$contains({
+      email: 'user@example.com',
+    })
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([
+      JSON.stringify({ profile: { email: 'user@example.com' } }),
+    ])
+    expect(query.sql).toBe(`${jsonObjectSql} @> $1::jsonb`)
+  })
+
+  it('generates root containment SQL from scalar proxy paths', () => {
+    const result = jsonContains(jsonObject).profile.status.$contains('active')
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([
+      JSON.stringify({ profile: { status: 'active' } }),
+    ])
+    expect(query.sql).toBe(`${jsonObjectSql} @> $1::jsonb`)
+  })
+
+  it('generates root containment SQL for array values', () => {
+    const result = jsonContains(jsonObject, {
+      tags: [{ name: 'tag1' }],
+    })
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([JSON.stringify({ tags: [{ name: 'tag1' }] })])
+    expect(query.sql).toBe(`${jsonObjectSql} @> $1::jsonb`)
+  })
+
+  it('generates root containment SQL from array proxy paths', () => {
+    const result = jsonContains(jsonObject).tags.$contains([{ name: 'tag1' }])
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([JSON.stringify({ tags: [{ name: 'tag1' }] })])
+    expect(query.sql).toBe(`${jsonObjectSql} @> $1::jsonb`)
+  })
+
+  it('accepts SQL containment values', () => {
+    const result = jsonContains(
+      jsonObject,
+      sql<JsonType>`jsonb_build_object('kind', 'alpha')`,
+    )
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([])
+    expect(query.sql).toBe(
+      `${jsonObjectSql} @> jsonb_build_object('kind', 'alpha')`,
+    )
+  })
+
+  it('accepts jsonBuild output as containment value', () => {
+    const result = jsonContains(
+      jsonObject,
+      jsonBuild({
+        profile: { status: 'active' },
+      }),
+    )
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([JSON.stringify('active')])
+    expect(query.sql).toBe(
+      `${jsonObjectSql} @> jsonb_build_object('profile', jsonb_build_object('status', $1::jsonb))`,
+    )
+  })
+
+  it('works with table columns', () => {
+    const result = jsonContains(table.jsoncol, { some: 'json' })
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([JSON.stringify({ some: 'json' })])
+    expect(query.sql).toBe(`"test"."jsoncol" @> $1::jsonb`)
+  })
+})

--- a/tests/json/indexes.test.ts
+++ b/tests/json/indexes.test.ts
@@ -1,0 +1,323 @@
+import { randomUUID } from 'node:crypto'
+import { type SQLWrapper, sql } from 'drizzle-orm'
+import { jsonb, pgTable } from 'drizzle-orm/pg-core'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { jsonAccess } from '../../src/json/operations/access.ts'
+import { jsonContains } from '../../src/json/operations/contains.ts'
+import { createDatabase, dialect, executeRows } from '../utils.ts'
+
+type IndexedJsonDocument = {
+  kind: 'alpha' | 'beta'
+  profile: {
+    email: string
+    status: 'active' | 'inactive'
+  }
+  tags: Array<{ name: string }>
+  flags: {
+    featured: boolean
+  }
+}
+
+type ExplainPlanNode = {
+  'Index Name'?: string
+  Plans?: ExplainPlanNode[]
+}
+
+type ExplainQueryRow = {
+  'QUERY PLAN': Array<{
+    Plan: ExplainPlanNode
+  }>
+}
+
+let db: Awaited<ReturnType<typeof createDatabase>>
+const createdTables: string[] = []
+const tableNameSuffixLength = 8
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+afterAll(async () => {
+  for (const tableName of createdTables) {
+    await db.execute(sql.raw(`drop table if exists "${tableName}";`))
+  }
+})
+
+const jsonbLiteral = (value: unknown) => sql`${JSON.stringify(value)}::jsonb`
+
+const executeRaw = (statement: string) => db.execute(sql.raw(statement))
+
+const explainQuery = async (query: SQLWrapper) => {
+  await db.execute(sql.raw('begin'))
+
+  try {
+    await executeRaw('set local enable_seqscan = off;')
+    const rows = await executeRows<ExplainQueryRow>(
+      db,
+      sql`explain (format json) ${query}`,
+    )
+
+    return rows[0]!['QUERY PLAN'][0]!.Plan
+  } finally {
+    await executeRaw('rollback')
+  }
+}
+
+const runQuery = async <TRow extends Record<string, unknown>>(
+  query: SQLWrapper,
+) => executeRows<TRow>(db, query)
+
+const findIndexNames = (plan: ExplainPlanNode): string[] => [
+  ...(plan['Index Name'] ? [plan['Index Name']] : []),
+  ...(plan.Plans?.flatMap(findIndexNames) ?? []),
+]
+
+const getRegisteredIndexExpression = async (indexName: string) => {
+  const rows = await executeRows<{ expression?: string }>(
+    db,
+    sql`
+      select pg_get_expr(i.indexprs, i.indrelid) as expression
+      from pg_index i
+      join pg_class c on c.oid = i.indexrelid
+      where c.relname = ${indexName}
+    `,
+  )
+
+  return rows[0]?.expression
+}
+
+const createSeededTable = async (suffix: string) => {
+  const tableName = `jsonb_idx_${suffix}_${randomUUID().replaceAll('-', '').slice(0, tableNameSuffixLength)}`
+  const indexedTable = pgTable(tableName, {
+    data: jsonb('data').$type<IndexedJsonDocument>().notNull(),
+  })
+
+  await executeRaw(`
+    create table "${tableName}" (
+      data jsonb not null
+    );
+  `)
+
+  await executeRaw(`
+    insert into "${tableName}" (data)
+    select jsonb_build_object(
+      'kind', case when g % 2 = 0 then 'alpha' else 'beta' end,
+      'profile', jsonb_build_object(
+        'email', 'user' || g || '@example.com',
+        'status', case when g % 3 = 0 then 'active' else 'inactive' end
+      ),
+      'tags', jsonb_build_array(
+        jsonb_build_object('name', 'tag' || (g % 10)),
+        jsonb_build_object('name', 'common')
+      ),
+      'flags', jsonb_build_object('featured', (g % 5 = 0))
+    )
+    from generate_series(1, 200) as g;
+  `)
+  createdTables.push(tableName)
+
+  return { indexedTable, tableName }
+}
+
+describe('JSONB index compatibility', () => {
+  it('uses a default GIN index for root jsonb containment predicates', async () => {
+    const { indexedTable, tableName } = await createSeededTable('gin')
+    const indexName = `${tableName}_gin_idx`
+    const kindAccessor = jsonAccess(indexedTable.data).kind.$text
+    const query = sql`
+      select ${kindAccessor} as kind
+      from ${indexedTable}
+      where ${indexedTable.data} @> ${jsonbLiteral({ kind: 'alpha' })}
+      limit 1
+    `
+    const countQuery = sql`
+      select count(*)::int as match_count
+      from ${indexedTable}
+      where ${indexedTable.data} @> ${jsonbLiteral({ kind: 'alpha' })}
+    `
+
+    const [baselineCount] = await runQuery<{ match_count: number }>(countQuery)
+    const [baselineRow] = await runQuery<{ kind: string }>(query)
+
+    expect(baselineCount?.match_count).toBe(100)
+    expect(baselineRow?.kind).toBe('alpha')
+
+    await executeRaw(
+      `create index "${indexName}" on "${tableName}" using gin (data);`,
+    )
+
+    const plan = await explainQuery(query)
+    const [indexedRow] = await runQuery<{ kind: string }>(query)
+
+    expect(findIndexNames(plan)).toContain(indexName)
+    expect(indexedRow?.kind).toBe('alpha')
+  })
+
+  it('uses a jsonb_path_ops GIN index for nested root containment predicates', async () => {
+    const { indexedTable, tableName } = await createSeededTable('path')
+    const indexName = `${tableName}_path_idx`
+    const emailAccessor = jsonAccess(indexedTable.data).profile.email.$text
+    const query = sql`
+      select ${emailAccessor} as email
+      from ${indexedTable}
+      where ${indexedTable.data} @> ${jsonbLiteral({
+        profile: { email: 'user42@example.com' },
+      })}
+    `
+    const countQuery = sql`
+      select count(*)::int as match_count
+      from ${indexedTable}
+      where ${indexedTable.data} @> ${jsonbLiteral({
+        profile: { email: 'user42@example.com' },
+      })}
+    `
+
+    const [baselineCount] = await runQuery<{ match_count: number }>(countQuery)
+    const [baselineRow] = await runQuery<{ email: string }>(query)
+
+    expect(baselineCount?.match_count).toBe(1)
+    expect(baselineRow?.email).toBe('user42@example.com')
+
+    await executeRaw(
+      `create index "${indexName}" on "${tableName}" using gin (data jsonb_path_ops);`,
+    )
+
+    const plan = await explainQuery(query)
+    const [indexedRow] = await runQuery<{ email: string }>(query)
+
+    expect(findIndexNames(plan)).toContain(indexName)
+    expect(indexedRow?.email).toBe('user42@example.com')
+  })
+
+  it('uses a btree expression index built from a jsonAccess $text expression', async () => {
+    const { indexedTable, tableName } = await createSeededTable('text')
+    const indexName = `${tableName}_email_idx`
+    const emailAccessor = jsonAccess(indexedTable.data).profile.email.$text
+    const indexExpression = dialect.sqlToQuery(
+      jsonAccess(sql<IndexedJsonDocument>`data`).profile.email.$text,
+    ).sql
+    const query = sql`
+      select ${emailAccessor} as email
+      from ${indexedTable}
+      where ${emailAccessor} = ${'user42@example.com'}
+    `
+
+    expect(indexExpression).toBe(
+      `jsonb_extract_path_text(data, 'profile','email')`,
+    )
+    expect(await getRegisteredIndexExpression(indexName)).toBeUndefined()
+    expect(await runQuery<{ email: string }>(query)).toEqual([
+      { email: 'user42@example.com' },
+    ])
+
+    await executeRaw(
+      `create index "${indexName}" on "${tableName}" (${indexExpression});`,
+    )
+
+    const plan = await explainQuery(query)
+
+    expect(await getRegisteredIndexExpression(indexName)).toBe(
+      `jsonb_extract_path_text(data, VARIADIC ARRAY['profile'::text, 'email'::text])`,
+    )
+    expect(findIndexNames(plan)).toContain(indexName)
+    expect(await runQuery<{ email: string }>(query)).toEqual([
+      { email: 'user42@example.com' },
+    ])
+  })
+
+  it('uses a GIN expression index built from a jsonAccess $value expression', async () => {
+    const { indexedTable, tableName } = await createSeededTable('value')
+    const indexName = `${tableName}_tags_idx`
+    const tagsAccessor = jsonAccess(indexedTable.data).tags.$value
+    const firstTagName = jsonAccess(indexedTable.data).tags['0'].name.$text
+    const secondTagName = jsonAccess(indexedTable.data).tags['1'].name.$text
+    const indexExpression = dialect.sqlToQuery(
+      jsonAccess(sql<IndexedJsonDocument>`data`).tags.$value,
+    ).sql
+    const query = sql`
+      select
+        ${firstTagName} as first_tag_name,
+        ${secondTagName} as second_tag_name
+      from ${indexedTable}
+      where ${tagsAccessor} @> ${jsonbLiteral([{ name: 'tag3' }])}
+      order by ${firstTagName}, ${secondTagName}
+    `
+
+    expect(indexExpression).toBe(`jsonb_extract_path(data, 'tags')`)
+    expect(await runQuery(query)).toHaveLength(20)
+
+    await executeRaw(
+      `create index "${indexName}" on "${tableName}" using gin ((${indexExpression}));`,
+    )
+
+    const plan = await explainQuery(query)
+    const indexedRows = await runQuery<{
+      first_tag_name: string
+      second_tag_name: string
+    }>(query)
+
+    expect(await getRegisteredIndexExpression(indexName)).toBe(
+      `jsonb_extract_path(data, VARIADIC ARRAY['tags'::text])`,
+    )
+    expect(findIndexNames(plan)).toContain(indexName)
+    expect(indexedRows).toHaveLength(20)
+    expect(new Set(indexedRows.map((row) => row.first_tag_name))).toEqual(
+      new Set(['tag3']),
+    )
+    expect(new Set(indexedRows.map((row) => row.second_tag_name))).toEqual(
+      new Set(['common']),
+    )
+  })
+
+  it('uses a full-column GIN index for jsonContains nested predicates', async () => {
+    const { indexedTable, tableName } = await createSeededTable('contains')
+    const indexName = `${tableName}_gin_idx`
+    const emailAccessor = jsonAccess(indexedTable.data).profile.email.$text
+    const query = sql`
+      select ${emailAccessor} as email
+      from ${indexedTable}
+      where ${jsonContains(indexedTable.data).profile.$contains({
+        email: 'user42@example.com',
+      })}
+    `
+
+    expect(await runQuery<{ email: string }>(query)).toEqual([
+      { email: 'user42@example.com' },
+    ])
+
+    await executeRaw(
+      `create index "${indexName}" on "${tableName}" using gin (data);`,
+    )
+
+    const plan = await explainQuery(query)
+
+    expect(findIndexNames(plan)).toContain(indexName)
+  })
+
+  it('uses a full-column jsonb_path_ops index for jsonContains array predicates', async () => {
+    const { indexedTable, tableName } = await createSeededTable('array')
+    const indexName = `${tableName}_path_idx`
+    const firstTagName = jsonAccess(indexedTable.data).tags['0'].name.$text
+    const query = sql`
+      select ${firstTagName} as first_tag_name
+      from ${indexedTable}
+      where ${jsonContains(indexedTable.data).tags.$contains([{ name: 'tag7' }])}
+      order by ${firstTagName}
+    `
+
+    const baselineRows = await runQuery<{ first_tag_name: string }>(query)
+
+    expect(baselineRows).toHaveLength(20)
+    expect(new Set(baselineRows.map((row) => row.first_tag_name))).toEqual(
+      new Set(['tag7']),
+    )
+
+    await executeRaw(
+      `create index "${indexName}" on "${tableName}" using gin (data jsonb_path_ops);`,
+    )
+
+    const plan = await explainQuery(query)
+
+    expect(findIndexNames(plan)).toContain(indexName)
+  })
+})

--- a/tests/json/integration.test.ts
+++ b/tests/json/integration.test.ts
@@ -6,6 +6,9 @@ import {
   jsonArrayPush,
   jsonArraySet,
 } from '../../src/json/operations/array.ts'
+import { jsonBuild } from '../../src/json/operations/build.ts'
+import { jsonCoalesce } from '../../src/json/operations/coalesce.ts'
+import { jsonContains } from '../../src/json/operations/contains.ts'
 import { jsonMerge } from '../../src/json/operations/merge.ts'
 import { jsonSet, jsonSetPipe } from '../../src/json/operations/set.ts'
 import { createDatabase, executeQuery, type TestDatabase } from '../utils.ts'
@@ -29,6 +32,7 @@ describe('JSON Integration Tests', () => {
     expect(jsonImport.setPipe).toBeDefined()
     expect(jsonImport.build).toBeDefined()
     expect(jsonImport.coalesce).toBeDefined()
+    expect(jsonImport.contains).toBeDefined()
 
     const jsonImportSet = await import('@denny-il/drizzle-pg-utils/json/set')
     expect(jsonImportSet.jsonSet).toBeDefined()
@@ -69,9 +73,103 @@ describe('JSON Integration Tests', () => {
     )
     expect(jsonImportCoalesce.jsonCoalesce).toBeDefined()
     expect(jsonImportCoalesce.jsonCoalesce).toEqual(jsonImport.coalesce)
+
+    const jsonImportContains = await import(
+      '@denny-il/drizzle-pg-utils/json/contains'
+    )
+    expect(jsonImportContains.jsonContains).toBeDefined()
+    expect(jsonImportContains.jsonContains).toEqual(jsonImport.contains)
   })
 
   describe('JSON Accessor Runtime Behavior', () => {
+    it('should test root containment correctly', async () => {
+      const value = sql<{
+        user: { id: number; name: string }
+      }>`'{"user": {"id": 123, "name": "John"}}'::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonContains(value, { user: { id: 123 } }),
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it('should test containment with jsonBuild values', async () => {
+      const value = sql<{
+        user: { id: number; name: string }
+      }>`'{"user": {"id": 123, "name": "John"}}'::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonContains(
+          value,
+          jsonBuild({
+            user: { name: 'John' },
+          }),
+        ),
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it('should test containment through proxy paths', async () => {
+      const value = sql<{
+        user: { id: number; name: string }
+      }>`'{"user": {"id": 123, "name": "John"}}'::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonContains(value).user.$contains({ name: 'John' }),
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it('should test containment against merged JSON values', async () => {
+      const base = sql<{
+        id: number
+      }>`'{"id": 123}'::jsonb`
+      const overlay = jsonBuild({
+        name: 'John',
+      })
+      const result = await executeQuery(
+        db,
+        jsonContains(jsonMerge(base, overlay), {
+          id: 123,
+          name: 'John',
+        }),
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it('should test containment against coalesced JSON values', async () => {
+      const nullableValue = sql<{
+        user: { id: number }
+      } | null>`NULL::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonContains(
+          jsonCoalesce(nullableValue, jsonBuild({ user: { id: 123 } })),
+          {
+            user: { id: 123 },
+          },
+        ),
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it('should test containment against accessed JSON subdocuments', async () => {
+      const value = sql<{
+        user: { id: number; name: string }
+      }>`'{"user": {"id": 123, "name": "John"}}'::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonContains(jsonAccess(value).user.$value, { name: 'John' }),
+      )
+
+      expect(result).toBe(true)
+    })
+
     it('should access nested properties correctly', async () => {
       const value = sql<{
         user: { id: number; name: string }

--- a/tests/json/sql-injection-contains.test.ts
+++ b/tests/json/sql-injection-contains.test.ts
@@ -1,0 +1,100 @@
+import { sql } from 'drizzle-orm'
+import { beforeAll, describe, expect, it } from 'vitest'
+import * as json from '../../src/json/index.ts'
+import { jsonBuild } from '../../src/json/operations/build.ts'
+import { jsonContains } from '../../src/json/operations/contains.ts'
+import {
+  createDatabase,
+  dialect,
+  executeQuery,
+  type TestDatabase,
+} from '../utils.ts'
+
+let db: TestDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+describe('JSON Contains SQL injection and misuse resistance', () => {
+  it('keeps malicious direct containment values parameterized', async () => {
+    const source = sql`'{"safe":true,"payload":"kept"}'::jsonb`
+    const maliciousValue = `value'); drop table contains_sentinel; --`
+    const result = jsonContains(source, { payload: maliciousValue })
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `'{"safe":true,"payload":"kept"}'::jsonb @> $1::jsonb`,
+    )
+    expect(query.sql).not.toContain(maliciousValue)
+    expect(query.params).toEqual([JSON.stringify({ payload: maliciousValue })])
+    await expect(executeQuery(db, result)).resolves.toBe(false)
+  })
+
+  it('keeps malicious proxy path and value data parameterized', async () => {
+    const maliciousPath = `profile"} || '{"admin":true}'::jsonb || '{"profile`
+    const maliciousValue = `dark'); select pg_sleep(99); --`
+    const source = sql`'{"profile\":{\"theme\":\"dark\"}}'::jsonb`
+    const result = jsonContains(source)[maliciousPath].$contains(maliciousValue)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(`'{"profile":{"theme":"dark"}}'::jsonb @> $1::jsonb`)
+    expect(query.sql).not.toContain(maliciousPath)
+    expect(query.sql).not.toContain(maliciousValue)
+    expect(query.params).toEqual([
+      JSON.stringify({ [maliciousPath]: maliciousValue }),
+    ])
+    await expect(executeQuery(db, result)).resolves.toBe(false)
+  })
+
+  it('preserves SQLWrapper placeholders and params as caller-controlled SQL', () => {
+    const payload = `wrapped'); drop table contains_sentinel; --`
+    const source = sql`'{"payload":"wrapped"}'::jsonb`
+    const result = jsonContains(
+      source,
+      sql`jsonb_build_object('payload', ${payload})`,
+    )
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `'{"payload":"wrapped"}'::jsonb @> jsonb_build_object('payload', $1)`,
+    )
+    expect(query.sql).not.toContain(payload)
+    expect(query.params).toEqual([payload])
+  })
+
+  it('public contains alias generates the same SQL and params as jsonContains', () => {
+    const source = jsonBuild({ stable: true })
+    const value = {
+      payload: `alias'); drop table contains_sentinel; --`,
+    }
+
+    expect(dialect.sqlToQuery(json.contains(source, value))).toEqual(
+      dialect.sqlToQuery(jsonContains(source, value)),
+    )
+  })
+
+  it('preserves malicious containment data at runtime without executing it', async () => {
+    await db.execute(
+      sql`create table contains_sentinel (id integer primary key)`,
+    )
+    await db.execute(sql`insert into contains_sentinel (id) values (1)`)
+
+    const maliciousKey = `key'); drop table contains_sentinel; --`
+    const maliciousValue = `value'); drop table contains_sentinel; --`
+    const source = jsonBuild({
+      safe: true,
+      [maliciousKey]: maliciousValue,
+    })
+
+    await expect(
+      executeQuery(
+        db,
+        jsonContains(source, { [maliciousKey]: maliciousValue }),
+      ),
+    ).resolves.toBe(true)
+    await expect(
+      executeQuery(db, sql`(select count(*)::int from contains_sentinel)`),
+    ).resolves.toBe(1)
+  })
+})

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -63,7 +63,17 @@ export const executeQuery = async (
   client: TestDatabase,
   query: SQLWrapper,
 ): Promise<any> => {
-  const results = await client.execute(sql`select (${query}) as result`)
-  const rows = Array.isArray(results) ? results : results.rows
+  const rows = await executeRows<{ result: unknown }>(
+    client,
+    sql`select (${query}) as result`,
+  )
   return rows[0]!.result
+}
+
+export const executeRows = async <TRow extends Record<string, unknown>>(
+  client: TestDatabase,
+  query: SQLWrapper,
+): Promise<TRow[]> => {
+  const results = await client.execute(query)
+  return (Array.isArray(results) ? results : results.rows) as TRow[]
 }


### PR DESCRIPTION
## Summary

- add typed `json.contains(...)` direct and proxy APIs for JSONB containment
- keep proxy predicates rooted at the source column so full-column GIN/path_ops indexes can be used
- add index compatibility tests covering full-column GIN/path_ops plus expression-index behavior
- add runtime/type coverage for `json.build`, `json.merge`, `json.coalesce`, and `json.access(...).$value` interop
- document the final containment API in README, JSON docs, and repo skill reference

## Validation

- `pnpm vitest run tests/json/indexes.test.ts tests/json/contains.test.ts`
- `pnpm run fmt`
- `pnpm run test`
- `pnpm run check`
