### PR TITLE
Fix JSON helper edge cases

### DIFF
--- a/src/json/operations/array.ts
+++ b/src/json/operations/array.ts
@@ -93,7 +93,7 @@ export function jsonArraySet<
   const _value = isSQLWrapper(value)
     ? jsonBuild(value as any)
     : jsonbLiteral(value)
-  return sql<SourceType>`jsonb_set(${valueOrEmptyArray(target)}, '{${sql`${index}`.inlineParams()}}', ${_value})`
+  return sql<SourceType>`jsonb_set(${valueOrEmptyArray(target)}, '{${sql`${index}`.inlineParams()}}', ${_value}, false)`
 }
 
 /**

--- a/src/json/operations/array.ts
+++ b/src/json/operations/array.ts
@@ -9,6 +9,10 @@ import { jsonBuild } from './build.ts'
 
 type AcceptableValue = any[] | SQLJSONNullish
 
+function jsonbLiteral(value: unknown) {
+  return sql`${JSON.stringify(value === undefined ? null : value)}::jsonb`
+}
+
 function valueOrEmptyArray<T extends SQLJSONValue<AcceptableValue>>(
   value: T,
 ): SQL<SQLJSONDenullify<SQLJSONExtractType<T>>> {
@@ -48,7 +52,7 @@ export function jsonArrayPush<
   ...values: Array<ElementType | SQLJSONValue<ElementType>>
 ): SQL<SQLJSONDenullify<SourceType>> {
   const _values = values.map((value) =>
-    isSQLWrapper(value) ? value : sql`${JSON.stringify(value)}::jsonb`,
+    isSQLWrapper(value) ? value : jsonbLiteral(value),
   )
   const _value = sql`jsonb_build_array(${sql.join(_values, sql`, `)})`
   return sql`${valueOrEmptyArray(target)} || ${_value}`
@@ -88,7 +92,7 @@ export function jsonArraySet<
 ) {
   const _value = isSQLWrapper(value)
     ? jsonBuild(value as any)
-    : sql`${JSON.stringify(value)}::jsonb`
+    : jsonbLiteral(value)
   return sql<SourceType>`jsonb_set(${valueOrEmptyArray(target)}, '{${sql`${index}`.inlineParams()}}', ${_value})`
 }
 

--- a/src/json/operations/array.ts
+++ b/src/json/operations/array.ts
@@ -5,17 +5,16 @@ import type {
   SQLJSONNullish,
   SQLJSONValue,
 } from '../common.ts'
-import { jsonCoalesce } from './coalesce.ts'
+import { jsonBuild } from './build.ts'
 
 type AcceptableValue = any[] | SQLJSONNullish
 
 function valueOrEmptyArray<T extends SQLJSONValue<AcceptableValue>>(
   value: T,
 ): SQL<SQLJSONDenullify<SQLJSONExtractType<T>>> {
-  return jsonCoalesce(
-    value,
-    sql<SQLJSONDenullify<SQLJSONExtractType<T>>>`'[]'::jsonb`,
-  )
+  return sql<
+    SQLJSONDenullify<SQLJSONExtractType<T>>
+  >`coalesce(nullif(${value}, 'null'::jsonb), '[]'::jsonb)`
 }
 
 /**
@@ -88,7 +87,7 @@ export function jsonArraySet<
   value: ElementType | SQLJSONValue<ElementType>,
 ) {
   const _value = isSQLWrapper(value)
-    ? value
+    ? jsonBuild(value as any)
     : sql`${JSON.stringify(value)}::jsonb`
   return sql<SourceType>`jsonb_set(${valueOrEmptyArray(target)}, '{${sql`${index}`.inlineParams()}}', ${_value})`
 }

--- a/src/json/operations/build.ts
+++ b/src/json/operations/build.ts
@@ -34,9 +34,24 @@ export type SQLJSONBuildUnwrapType<T extends SQLJSONBuildMixedType> =
 export function jsonBuild<T extends SQLJSONBuildMixedType>(
   value: T,
 ): SQL<SQLJSONBuildUnwrapType<T>> {
+  function isEmptyStringChunk(chunk: unknown) {
+    const value = (chunk as { value?: unknown }).value
+    return Array.isArray(value) && value.length === 1 && value[0] === ''
+  }
+
+  function isBareParamSQL(value: SQLWrapper) {
+    const queryChunks = (value as { queryChunks?: unknown[] }).queryChunks
+    return (
+      Array.isArray(queryChunks) &&
+      queryChunks.length === 3 &&
+      isEmptyStringChunk(queryChunks[0]) &&
+      isEmptyStringChunk(queryChunks[2])
+    )
+  }
+
   function processValue(value: any): SQLWrapper {
-    // If it's already an SQL object, return as-is
-    if (isSQLWrapper(value)) return value
+    if (isSQLWrapper(value))
+      return isBareParamSQL(value) ? value : sql`to_jsonb(${value})`
 
     // Handle arrays with mixed JS/SQL values
     if (Array.isArray(value)) {

--- a/src/json/operations/coalesce.ts
+++ b/src/json/operations/coalesce.ts
@@ -1,10 +1,10 @@
 import { type SQL, sql } from 'drizzle-orm'
-import {
-  normalizeNullish,
-  type SQLJSONDenullify,
-  type SQLJSONExtractType,
-  type SQLJSONValue,
+import type {
+  SQLJSONDenullify,
+  SQLJSONExtractType,
+  SQLJSONValue,
 } from '../common.ts'
+import { jsonBuild } from './build.ts'
 
 /**
  * Coalesce two JSON values, returning the first non-nullish value.
@@ -19,5 +19,5 @@ export function jsonCoalesce<
 ): SQL<
   SQLJSONDenullify<SQLJSONExtractType<Source>> | SQLJSONExtractType<Value>
 > {
-  return sql`json_query(${normalizeNullish(source)}, 'strict $ ? (@ != null)' default ${value} on empty)::jsonb`
+  return sql`coalesce(nullif(${source}, 'null'::jsonb), ${jsonBuild(value as any)})`
 }

--- a/src/json/operations/set.ts
+++ b/src/json/operations/set.ts
@@ -78,7 +78,7 @@ export function jsonSet<Source extends SQLJSONValue<object>>(
         path.map((p) => sql`${p}`.inlineParams()),
         sql`,`,
       )}]::text[]`
-      return sql`jsonb_set(${source}, ${pathArray}, ${setValueSQL}, ${sql`${createMissing}`.inlineParams()})`
+      return sql`jsonb_set(${source}, ${pathArray}, ${setValueSQL}, ${sql`${!!createMissing}`.inlineParams()})`
     }
 
     function buildDefault(path: string[], value: any, createMissing = true) {
@@ -92,7 +92,7 @@ export function jsonSet<Source extends SQLJSONValue<object>>(
       const pathArray = sql`array[${pathArgs}]::text[]`
       const currentValueSQL = sql`jsonb_extract_path(${source}, ${pathArgs})`
       return _jsonSet(
-        sql`jsonb_set(coalesce(nullif(${source}, 'null'::jsonb), '{}'::jsonb), ${pathArray}, coalesce(nullif(${currentValueSQL}, 'null'::jsonb), ${defaultValueSQL}), ${sql`${createMissing}`.inlineParams()})` as Source,
+        sql`jsonb_set(coalesce(nullif(${source}, 'null'::jsonb), '{}'::jsonb), ${pathArray}, coalesce(nullif(${currentValueSQL}, 'null'::jsonb), ${defaultValueSQL}), ${sql`${!!createMissing}`.inlineParams()})` as Source,
         path,
       )
     }

--- a/src/json/operations/set.ts
+++ b/src/json/operations/set.ts
@@ -1,15 +1,13 @@
 import { sql } from 'drizzle-orm'
 import type { AnyPgColumn } from 'drizzle-orm/pg-core'
 import type { SQL } from 'drizzle-orm/sql'
-import {
-  normalizeNullish,
-  type SQLJSONDenullify,
-  type SQLJSONExtractType,
-  type SQLJSONIsNullish,
-  type SQLJSONValue,
+import type {
+  SQLJSONDenullify,
+  SQLJSONExtractType,
+  SQLJSONIsNullish,
+  SQLJSONValue,
 } from '../common.ts'
 import { jsonBuild } from './build.ts'
-import { jsonCoalesce } from './coalesce.ts'
 
 export type SQLJSONSetMixedValue<T> =
   | SQL<T>
@@ -92,8 +90,9 @@ export function jsonSet<Source extends SQLJSONValue<object>>(
         sql`,`,
       )
       const pathArray = sql`array[${pathArgs}]::text[]`
+      const currentValueSQL = sql`jsonb_extract_path(${source}, ${pathArgs})`
       return _jsonSet(
-        sql`jsonb_set(${source}, ${pathArray}, ${jsonCoalesce(sql`jsonb_extract_path(${source}, ${pathArgs})`, defaultValueSQL)}, ${sql`${createMissing}`.inlineParams()})` as Source,
+        sql`jsonb_set(coalesce(nullif(${source}, 'null'::jsonb), '{}'::jsonb), ${pathArray}, coalesce(nullif(${currentValueSQL}, 'null'::jsonb), ${defaultValueSQL}), ${sql`${createMissing}`.inlineParams()})` as Source,
         path,
       )
     }
@@ -170,6 +169,6 @@ export function jsonSetPipe<Source extends SQLJSONValue<object>>(
       const setter = jsonSet(acc)
       return fn(setter as any)
     },
-    normalizeNullish(source) as SQL<SQLJSONExtractType<Source>>,
+    source as SQL<SQLJSONExtractType<Source>>,
   )
 }

--- a/tests/json/access.test.ts
+++ b/tests/json/access.test.ts
@@ -1,6 +1,7 @@
 import { type SQL, sql } from 'drizzle-orm'
 
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { SQLJSONExtractType } from '../../src/json/common.ts'
 import {
   jsonAccess,
   type SQLJSONAccess,
@@ -151,6 +152,18 @@ describe('JSON Accessor', () => {
       expectTypeOf(
         accessor.user.profile.preferences.notifications.$text,
       ).toEqualTypeOf<SQL<string>>()
+    })
+
+    it('treats readonly array element access as nullable', () => {
+      const accessor = jsonAccess(
+        sql<{ items: readonly string[] }>`'{"items": ["a"]}'::jsonb`,
+      )
+      const itemValue = accessor.items[0].$value
+
+      expectTypeOf<SQLJSONExtractType<typeof itemValue>>().toEqualTypeOf<
+        string | null
+      >()
+      expectTypeOf(itemValue).toEqualTypeOf<SQL<string | null>>()
     })
   })
 

--- a/tests/json/array.test.ts
+++ b/tests/json/array.test.ts
@@ -32,7 +32,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['4'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
 
@@ -42,7 +42,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['4', '5', '6'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb, $2::jsonb, $3::jsonb)`,
+        `coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb, $2::jsonb, $3::jsonb)`,
       )
     })
 
@@ -52,7 +52,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['"d"', '"e"'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${stringArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb, $2::jsonb)`,
+        `coalesce(nullif(${stringArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb, $2::jsonb)`,
       )
     })
 
@@ -63,7 +63,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['{"id":3,"name":"Bob"}'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${objectArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif(${objectArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
 
@@ -74,7 +74,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array('42'::jsonb)`,
+        `coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array('42'::jsonb)`,
       )
     })
 
@@ -84,7 +84,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['"first"'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${emptyArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif(${emptyArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
 
@@ -94,7 +94,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['1'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${nullableArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif(${nullableArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
 
@@ -111,7 +111,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([99].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{1}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1::jsonb)`,
       )
     })
 
@@ -121,7 +121,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['new'].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${stringArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${stringArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
       )
     })
 
@@ -132,7 +132,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([newUser].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${objectArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${objectArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
       )
     })
 
@@ -143,7 +143,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{2}', '777'::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{2}', to_jsonb('777'::jsonb))`,
       )
     })
 
@@ -154,7 +154,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([42])
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{1}', $1)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1)`,
       )
     })
 
@@ -164,7 +164,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([99].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{-1}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{-1}', $1::jsonb)`,
       )
     })
 
@@ -181,7 +181,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb - 1`,
+        `coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb) - 1`,
       )
     })
 
@@ -191,7 +191,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `json_query(coalesce(${stringArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb - 0`,
+        `coalesce(nullif(${stringArraySql}, 'null'::jsonb), '[]'::jsonb) - 0`,
       )
     })
 
@@ -201,7 +201,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb - -1`,
+        `coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb) - -1`,
       )
     })
 
@@ -213,7 +213,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `json_query(coalesce('[1, 2, 3]'::jsonb, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb - 0`,
+        `coalesce(nullif('[1, 2, 3]'::jsonb, 'null'::jsonb), '[]'::jsonb) - 0`,
       )
     })
 
@@ -259,7 +259,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['[7,8]'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${nestedArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif(${nestedArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
   })
@@ -271,7 +271,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['null'])
       expect(query.sql).toBe(
-        `json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
 
@@ -281,7 +281,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([null].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce(${numberArraySql}, 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
       )
     })
 
@@ -314,7 +314,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['{"id":3,"name":"new-item"}'])
       expect(query.sql).toBe(
-        `json_query(coalesce("test"."arraycol", 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb || jsonb_build_array($1::jsonb)`,
+        `coalesce(nullif("test"."arraycol", 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
       )
     })
 
@@ -329,7 +329,7 @@ describe('JSON Array Operations', () => {
         [{ id: 1, name: 'updated-item' }].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(json_query(coalesce("test"."arraycol", 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb, '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif("test"."arraycol", 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
       )
     })
 
@@ -339,7 +339,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `json_query(coalesce("test"."arraycol", 'null'::jsonb), 'strict $ ? (@ != null)' default '[]'::jsonb on empty)::jsonb - 0`,
+        `coalesce(nullif("test"."arraycol", 'null'::jsonb), '[]'::jsonb) - 0`,
       )
     })
   })

--- a/tests/json/array.test.ts
+++ b/tests/json/array.test.ts
@@ -1,5 +1,6 @@
 import { type SQL, sql } from 'drizzle-orm'
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { SQLJSONExtractType } from '../../src/json/common.ts'
 import {
   jsonArrayDelete,
   jsonArrayPush,
@@ -171,6 +172,15 @@ describe('JSON Array Operations', () => {
     it('has correct return type', () => {
       const result = jsonArraySet(numberArray, 1, 42)
       expectTypeOf(result).toEqualTypeOf<import('drizzle-orm').SQL<number[]>>()
+    })
+
+    it('types nullable arrays as concrete arrays', () => {
+      const result = jsonArraySet(nullableArray, 0, 1)
+
+      expectTypeOf<SQLJSONExtractType<typeof result>>().toEqualTypeOf<
+        number[]
+      >()
+      expectTypeOf(result).toEqualTypeOf<SQL<number[]>>()
     })
   })
 

--- a/tests/json/array.test.ts
+++ b/tests/json/array.test.ts
@@ -111,7 +111,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([99].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1::jsonb, false)`,
       )
     })
 
@@ -121,7 +121,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual(['new'].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${stringArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${stringArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
       )
     })
 
@@ -132,7 +132,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([newUser].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${objectArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${objectArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
       )
     })
 
@@ -143,7 +143,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([])
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{2}', to_jsonb('777'::jsonb))`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{2}', to_jsonb('777'::jsonb), false)`,
       )
     })
 
@@ -154,7 +154,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([42])
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1, false)`,
       )
     })
 
@@ -164,7 +164,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([99].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{-1}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{-1}', $1::jsonb, false)`,
       )
     })
 
@@ -281,7 +281,7 @@ describe('JSON Array Operations', () => {
 
       expect(query.params).toEqual([null].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif(${numberArraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
       )
     })
 
@@ -329,7 +329,7 @@ describe('JSON Array Operations', () => {
         [{ id: 1, name: 'updated-item' }].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(coalesce(nullif("test"."arraycol", 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb)`,
+        `jsonb_set(coalesce(nullif("test"."arraycol", 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
       )
     })
 

--- a/tests/json/build.test.ts
+++ b/tests/json/build.test.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 import { jsonBuild } from '../../src/json/operations/build.ts'
-import { dialect } from '../utils.ts'
+import { dialect, table } from '../utils.ts'
 
 describe('JSON Build', () => {
   it('casts SQL primitives to jsonb', () => {
@@ -29,5 +29,11 @@ describe('JSON Build', () => {
 
     expect(query.params).toEqual([JSON.stringify('hello')])
     expect(query.sql).toBe(`$1::jsonb`)
+  })
+
+  it('accepts column SQL wrappers inside objects', () => {
+    const result = jsonBuild({ columnValue: table.jsoncol })
+
+    expect(result).toBeDefined()
   })
 })

--- a/tests/json/common.test.ts
+++ b/tests/json/common.test.ts
@@ -66,6 +66,7 @@ describe('JSON Common Types and Utilities', () => {
       const result = normalizeNullish(jsonValue)
 
       expect(result).toBeDefined()
+      expectTypeOf(result).toEqualTypeOf<SQL<{ test: string }>>()
     })
 
     it('works with different JSON types', () => {

--- a/tests/json/integration.test.ts
+++ b/tests/json/integration.test.ts
@@ -757,12 +757,28 @@ describe('JSON Integration Tests', () => {
       expect(result).toEqual(['a', 'b', 'c'])
     })
 
+    it('should push undefined values as JSON null', async () => {
+      const baseArray = sql<Array<string | null>>`'["a"]'::jsonb`
+      const pushedArray = jsonArrayPush(baseArray, undefined)
+      const result = await executeQuery(db, pushedArray)
+
+      expect(result).toEqual(['a', null])
+    })
+
     it('should set array elements by index', async () => {
       const baseArray = sql<string[]>`'["a", "b", "c"]'::jsonb`
       const updatedArray = jsonArraySet(baseArray, 1, 'updated')
       const result = await executeQuery(db, updatedArray)
 
       expect(result).toEqual(['a', 'updated', 'c'])
+    })
+
+    it('should set undefined values as JSON null', async () => {
+      const baseArray = sql<Array<string | null>>`'["a", "b"]'::jsonb`
+      const updatedArray = jsonArraySet(baseArray, 1, undefined)
+      const result = await executeQuery(db, updatedArray)
+
+      expect(result).toEqual(['a', null])
     })
 
     it('should delete array elements by index', async () => {

--- a/tests/json/integration.test.ts
+++ b/tests/json/integration.test.ts
@@ -792,16 +792,17 @@ describe('JSON Integration Tests', () => {
     it('should handle out-of-bounds array operations gracefully', async () => {
       const baseArray = sql<string[]>`'["a", "b"]'::jsonb`
 
-      // Set out of bounds - PostgreSQL jsonb_set doesn't extend with nulls like I expected
-      const extendedArray = jsonArraySet(baseArray, 5, 'far')
-      const extendedResult = await executeQuery(db, extendedArray)
+      const setPastEnd = jsonArraySet(baseArray, 5, 'far')
+      const setBeforeStart = jsonArraySet(baseArray, -5, 'far')
+      const pastEndResult = await executeQuery(db, setPastEnd)
+      const beforeStartResult = await executeQuery(db, setBeforeStart)
 
       // Delete out of bounds (should be no-op)
       const deleteOutOfBounds = jsonArrayDelete(baseArray, 10)
       const deleteResult = await executeQuery(db, deleteOutOfBounds)
 
-      // PostgreSQL behavior: setting out of bounds just appends at the end
-      expect(extendedResult).toEqual(['a', 'b', 'far'])
+      expect(pastEndResult).toEqual(['a', 'b'])
+      expect(beforeStartResult).toEqual(['a', 'b'])
       expect(deleteResult).toEqual(['a', 'b'])
     })
 

--- a/tests/json/integration.test.ts
+++ b/tests/json/integration.test.ts
@@ -240,6 +240,17 @@ describe('JSON Integration Tests', () => {
 
       expect(result).toEqual({ user: { age: 42 } })
     })
+
+    it('should convert non-jsonb SQL values before jsonSet writes them', async () => {
+      const baseValue = sql<{ lastLogin?: string }>`'{}'::jsonb`
+
+      const result = await executeQuery(
+        db,
+        jsonSet(baseValue).lastLogin.$set(sql<string>`'2026-03-15'::text`),
+      )
+
+      expect(result).toEqual({ lastLogin: '2026-03-15' })
+    })
   })
 
   describe('JSON Set $default Runtime Behavior', () => {
@@ -260,6 +271,19 @@ describe('JSON Integration Tests', () => {
         user: { name: 'John' },
         profile: { avatar: 'new-avatar.jpg', theme: 'light' },
       })
+    })
+
+    it('should initialize SQL NULL root through $default', async () => {
+      const baseValue = sql<{
+        user?: { name: string }
+      }>`NULL::jsonb`
+      const setter = jsonSet(baseValue)
+      const result = await executeQuery(
+        db,
+        setter.user.$default({ name: 'Default User' }).name.$set('Ada'),
+      )
+
+      expect(result).toEqual({ user: { name: 'Ada' } })
     })
 
     it('should preserve existing value when property exists', async () => {
@@ -686,6 +710,32 @@ describe('JSON Integration Tests', () => {
       expect(result).toEqual({
         user: { name: 'John', settings: { theme: 'dark' } },
       })
+    })
+
+    it('should initialize SQL NULL root through jsonSetPipe and $default', async () => {
+      const baseValue = sql<{
+        user?: { name: string }
+      }>`NULL::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonSetPipe(baseValue, (s) =>
+          s.user.$default({ name: 'Default User' }).name.$set('Ada'),
+        ),
+      )
+
+      expect(result).toEqual({ user: { name: 'Ada' } })
+    })
+
+    it('should not auto-create SQL NULL root in jsonSetPipe without $default', async () => {
+      const baseValue = sql<{
+        user: { name: string }
+      }>`NULL::jsonb`
+      const result = await executeQuery(
+        db,
+        jsonSetPipe(baseValue, (s) => s.user.name.$set('Ada')),
+      )
+
+      expect(result).toBeNull()
     })
   })
 

--- a/tests/json/merge.test.ts
+++ b/tests/json/merge.test.ts
@@ -1,6 +1,7 @@
 import { type SQL, sql } from 'drizzle-orm'
 
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { SQLJSONExtractType } from '../../src/json/common.ts'
 import { jsonMerge } from '../../src/json/operations/merge.ts'
 import { dialect, table } from '../utils.ts'
 
@@ -281,6 +282,34 @@ describe('JSON Merge Operations', () => {
 
       const result = jsonMerge(obj1, obj2)
       expectTypeOf(result).toEqualTypeOf<SQL<{ a: string } & { b: number }>>()
+    })
+
+    it('types object merges as shallow right-wins merges', () => {
+      const left = sql<{
+        keep: boolean
+        user: { name: string }
+      }>`'{"keep": true, "user": {"name": "John"}}'::jsonb`
+      const right = sql<{
+        user: { age: number }
+      }>`'{"user": {"age": 30}}'::jsonb`
+
+      const result = jsonMerge(left, right)
+
+      expectTypeOf<SQLJSONExtractType<typeof result>>().toEqualTypeOf<{
+        keep: boolean
+        user: { age: number }
+      }>()
+    })
+
+    it('types duplicate object keys as right-hand values', () => {
+      const left = sql<{ key: string }>`'{"key": "old"}'::jsonb`
+      const right = sql<{ key: number }>`'{"key": 42}'::jsonb`
+
+      const result = jsonMerge(left, right)
+
+      expectTypeOf<SQLJSONExtractType<typeof result>>().toEqualTypeOf<{
+        key: number
+      }>()
     })
 
     it('has correct return type for array merge', () => {

--- a/tests/json/set.test.ts
+++ b/tests/json/set.test.ts
@@ -158,7 +158,7 @@ describe('JSON Set', () => {
         ['js-tag', 'another-js-tag'].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(${jsonObjectSql}, array['tags']::text[], jsonb_build_array($1::jsonb,'sql-generated-tag'::text,$2::jsonb), true)`,
+        `jsonb_set(${jsonObjectSql}, array['tags']::text[], jsonb_build_array($1::jsonb,to_jsonb('sql-generated-tag'::text),$2::jsonb), true)`,
       )
     })
 
@@ -203,7 +203,7 @@ describe('JSON Set', () => {
 
       expect(query.params).toEqual(['js-value'].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(${jsonObjectSql}, array['metadata']::text[], jsonb_build_object('jsKey', $1::jsonb,'sqlKey', 42::integer), true)`,
+        `jsonb_set(${jsonObjectSql}, array['metadata']::text[], jsonb_build_object('jsKey', $1::jsonb,'sqlKey', to_jsonb(42::integer)), true)`,
       )
     })
 
@@ -234,7 +234,7 @@ describe('JSON Set', () => {
 
       expect(query.params).toEqual([].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(${jsonObjectSql}, array['name']::text[], 'direct-sql-value'::text, true)`,
+        `jsonb_set(${jsonObjectSql}, array['name']::text[], to_jsonb('direct-sql-value'::text), true)`,
       )
     })
 
@@ -246,7 +246,7 @@ describe('JSON Set', () => {
 
       expect(query.params).toEqual([].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(${jsonObjectSql}, array['metadata']::text[], jsonb_build_object('computed', now()::text), true)`,
+        `jsonb_set(${jsonObjectSql}, array['metadata']::text[], to_jsonb(jsonb_build_object('computed', now()::text)), true)`,
       )
     })
   })
@@ -533,7 +533,7 @@ describe('JSON Set', () => {
         ['new-avatar.jpg', 'dark'].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(jsonb_set(coalesce(${jsonObjectSql}, 'null'::jsonb), array['profile','avatar']::text[], $1::jsonb, true), array['profile','settings','theme']::text[], $2::jsonb, true)`,
+        `jsonb_set(jsonb_set(${jsonObjectSql}, array['profile','avatar']::text[], $1::jsonb, true), array['profile','settings','theme']::text[], $2::jsonb, true)`,
       )
     })
   })
@@ -550,7 +550,7 @@ describe('JSON Set', () => {
         ['default', 'updated'].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(jsonb_set(${jsonObjectSql}, array['optionalObject']::text[], json_query(coalesce(jsonb_extract_path(${jsonObjectSql}, 'optionalObject'), 'null'::jsonb), 'strict $ ? (@ != null)' default jsonb_build_object('key', $1::jsonb) on empty)::jsonb, true), array['optionalObject','key']::text[], $2::jsonb, true)`,
+        `jsonb_set(jsonb_set(coalesce(nullif(${jsonObjectSql}, 'null'::jsonb), '{}'::jsonb), array['optionalObject']::text[], coalesce(nullif(jsonb_extract_path(${jsonObjectSql}, 'optionalObject'), 'null'::jsonb), jsonb_build_object('key', $1::jsonb)), true), array['optionalObject','key']::text[], $2::jsonb, true)`,
       )
     })
 
@@ -565,7 +565,7 @@ describe('JSON Set', () => {
         ['default1', 'default2', 'updated'].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(jsonb_set(${jsonObjectSql}, array['optionalArray']::text[], json_query(coalesce(jsonb_extract_path(${jsonObjectSql}, 'optionalArray'), 'null'::jsonb), 'strict $ ? (@ != null)' default jsonb_build_array(jsonb_build_object('key', $1::jsonb),jsonb_build_object('key', $2::jsonb)) on empty)::jsonb, true), array['optionalArray','0','key']::text[], $3::jsonb, true)`,
+        `jsonb_set(jsonb_set(coalesce(nullif(${jsonObjectSql}, 'null'::jsonb), '{}'::jsonb), array['optionalArray']::text[], coalesce(nullif(jsonb_extract_path(${jsonObjectSql}, 'optionalArray'), 'null'::jsonb), jsonb_build_array(jsonb_build_object('key', $1::jsonb),jsonb_build_object('key', $2::jsonb))), true), array['optionalArray','0','key']::text[], $3::jsonb, true)`,
       )
     })
 
@@ -580,7 +580,7 @@ describe('JSON Set', () => {
         ['default', 'updated'].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(jsonb_set(${jsonObjectSql}, array['optionalObject']::text[], json_query(coalesce(jsonb_extract_path(${jsonObjectSql}, 'optionalObject'), 'null'::jsonb), 'strict $ ? (@ != null)' default jsonb_build_object('key', $1::jsonb) on empty)::jsonb, false), array['optionalObject','key']::text[], $2::jsonb, true)`,
+        `jsonb_set(jsonb_set(coalesce(nullif(${jsonObjectSql}, 'null'::jsonb), '{}'::jsonb), array['optionalObject']::text[], coalesce(nullif(jsonb_extract_path(${jsonObjectSql}, 'optionalObject'), 'null'::jsonb), jsonb_build_object('key', $1::jsonb)), false), array['optionalObject','key']::text[], $2::jsonb, true)`,
       )
     })
 
@@ -596,7 +596,7 @@ describe('JSON Set', () => {
 
       expect(query.params).toEqual(['updated'].map((v) => JSON.stringify(v)))
       expect(query.sql).toBe(
-        `jsonb_set(jsonb_set(${jsonObjectSql}, array['optionalObject']::text[], json_query(coalesce(jsonb_extract_path(${jsonObjectSql}, 'optionalObject'), 'null'::jsonb), 'strict $ ? (@ != null)' default jsonb_build_object('key', 'sql-default') on empty)::jsonb, true), array['optionalObject','key']::text[], $1::jsonb, true)`,
+        `jsonb_set(jsonb_set(coalesce(nullif(${jsonObjectSql}, 'null'::jsonb), '{}'::jsonb), array['optionalObject']::text[], coalesce(nullif(jsonb_extract_path(${jsonObjectSql}, 'optionalObject'), 'null'::jsonb), to_jsonb(jsonb_build_object('key', 'sql-default'))), true), array['optionalObject','key']::text[], $1::jsonb, true)`,
       )
     })
 
@@ -615,7 +615,7 @@ describe('JSON Set', () => {
         ['defaultKey', 'defaultKey2', 'newValue'].map((v) => JSON.stringify(v)),
       )
       expect(query.sql).toBe(
-        `jsonb_set(jsonb_set(${jsonObjectSql}, array['optionalArray']::text[], json_query(coalesce(jsonb_extract_path(${jsonObjectSql}, 'optionalArray'), 'null'::jsonb), 'strict $ ? (@ != null)' default jsonb_build_array(jsonb_build_object('key', $1::jsonb,'key2', $2::jsonb)) on empty)::jsonb, true), array['optionalArray','0','key2']::text[], $3::jsonb, true)`,
+        `jsonb_set(jsonb_set(coalesce(nullif(${jsonObjectSql}, 'null'::jsonb), '{}'::jsonb), array['optionalArray']::text[], coalesce(nullif(jsonb_extract_path(${jsonObjectSql}, 'optionalArray'), 'null'::jsonb), jsonb_build_array(jsonb_build_object('key', $1::jsonb,'key2', $2::jsonb))), true), array['optionalArray','0','key2']::text[], $3::jsonb, true)`,
       )
     })
 

--- a/tests/json/set.test.ts
+++ b/tests/json/set.test.ts
@@ -390,6 +390,23 @@ describe('JSON Set', () => {
       // Should not have $default after using $default
       expectTypeOf(defaultResult).not.toHaveProperty('$default')
     })
+
+    it('does not expose array prototype members as JSON paths', () => {
+      const setter = jsonSet(jsonObject)
+
+      expectTypeOf(setter.tags).not.toHaveProperty('length')
+      expectTypeOf(setter.tags).not.toHaveProperty('map')
+    })
+
+    it('accepts null in nullable leaf setters', () => {
+      const setter = jsonSet(
+        sql<{ value: string | null }>`'{"value": "old"}'::jsonb`,
+      )
+
+      const result = setter.value.$set(null)
+
+      expect(result).toBeDefined()
+    })
   })
 
   describe('Edge Cases', () => {


### PR DESCRIPTION
## Summary

- Make JSON coalesce PostgreSQL 16-safe by avoiding json_query.
- Normalize SQL values written through JSON helpers via jsonBuild/to_jsonb handling.
- Make JSON array set replace-only and preserve undefined as JSON null.
- Coerce jsonSet createMissing to boolean before SQL generation.
- Add focused behavior and type coverage for JSON helpers.

## Validation

- pnpm exec vitest run tests/json/access.test.ts tests/json/array.test.ts tests/json/build.test.ts tests/json/common.test.ts tests/json/merge.test.ts tests/json/set.test.ts tests/json/integration.test.ts --reporter=dot
- pnpm run check:type
