### PR TITLE
Add JSON SQL injection coverage

### DIFF
--- a/tests/json/sql-injection-access.test.ts
+++ b/tests/json/sql-injection-access.test.ts
@@ -1,0 +1,145 @@
+import { access } from '@denny-il/drizzle-pg-utils/json'
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { jsonAccess } from '../../src/json/operations/access.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+let db: PgliteDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+const sqlString = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+const jsonLiteral = <T>(value: T) =>
+  sql<T>`${sql.raw(`${sqlString(JSON.stringify(value))}::jsonb`)}`
+
+const emptyJson = jsonLiteral<Record<string, unknown>>({})
+
+const hostileKeys = [
+  "name'); select pg_sleep(1); --",
+  "x' OR '1'='1",
+  'a,b',
+  'a/*comment*/b',
+  'a--comment',
+  "a->>'secret'",
+  "a#>>'{secret}'",
+  '{0,secret}',
+  '"quoted"',
+  'back\\slash',
+  'semi;colon',
+  ') from pg_catalog.pg_class --',
+] as const
+
+describe('jsonAccess SQL injection hardening', () => {
+  it.each(
+    hostileKeys,
+  )('renders hostile key %s as one escaped path literal', (key) => {
+    const accessor = jsonAccess(emptyJson) as any
+    const query = dialect.sqlToQuery(accessor[key].$value)
+
+    expect(query.params).toEqual([])
+    expect(query.sql).toBe(`jsonb_extract_path('{}'::jsonb, ${sqlString(key)})`)
+  })
+
+  it('renders hostile nested keys as separate escaped path literals', () => {
+    const firstKey = "safe','stolen"
+    const secondKey = "leaf'); drop table users; --"
+    const accessor = jsonAccess(emptyJson) as any
+    const query = dialect.sqlToQuery(accessor.root[firstKey][secondKey].$text)
+
+    expect(query.params).toEqual([])
+    expect(query.sql).toBe(
+      `jsonb_extract_path_text('{}'::jsonb, 'root',${sqlString(firstKey)},${sqlString(secondKey)})`,
+    )
+  })
+
+  it('keeps numeric-looking object keys as exact path segments', async () => {
+    const document = jsonLiteral({
+      numeric: {
+        '0': 'zero-key',
+        '01': 'leading-zero-key',
+        '-1': 'negative-key',
+        '1.5': 'decimal-key',
+        '1e2': 'exponent-key',
+      },
+      list: ['array-zero', 'array-one'],
+    })
+    const accessor = jsonAccess(document) as any
+
+    await expect(executeQuery(db, accessor.numeric['0'].$text)).resolves.toBe(
+      'zero-key',
+    )
+    await expect(executeQuery(db, accessor.numeric['01'].$text)).resolves.toBe(
+      'leading-zero-key',
+    )
+    await expect(executeQuery(db, accessor.numeric['-1'].$text)).resolves.toBe(
+      'negative-key',
+    )
+    await expect(executeQuery(db, accessor.numeric['1.5'].$text)).resolves.toBe(
+      'decimal-key',
+    )
+    await expect(executeQuery(db, accessor.numeric['1e2'].$text)).resolves.toBe(
+      'exponent-key',
+    )
+    await expect(executeQuery(db, accessor.list['0'].$text)).resolves.toBe(
+      'array-zero',
+    )
+  })
+
+  it('retrieves hostile keys literally instead of evaluating injected path syntax', async () => {
+    const pivotKey = "safe','stolen"
+    const operatorKey = "profile->>'admin'"
+    const commentKey = 'settings/*hidden*/'
+    const statementKey = "name'); select pg_sleep(1); --"
+    const document = jsonLiteral({
+      safe: { stolen: 'wrong-value' },
+      [pivotKey]: 'literal-pivot',
+      nested: {
+        [operatorKey]: {
+          [commentKey]: 'literal-nested',
+        },
+      },
+      [statementKey]: 'literal-statement',
+    })
+    const accessor = jsonAccess(document) as any
+
+    await expect(executeQuery(db, accessor[pivotKey].$text)).resolves.toBe(
+      'literal-pivot',
+    )
+    await expect(
+      executeQuery(db, accessor.nested[operatorKey][commentKey].$text),
+    ).resolves.toBe('literal-nested')
+    await expect(executeQuery(db, accessor[statementKey].$text)).resolves.toBe(
+      'literal-statement',
+    )
+    await expect(
+      executeQuery(db, accessor["safe','missing"].$text),
+    ).resolves.toBeNull()
+  })
+
+  it('applies same escaping through public access alias', async () => {
+    const key = "x' OR '1'='1"
+    const document = jsonLiteral({ [key]: 'alias-hit' })
+    const accessor = access(document) as any
+    const query = dialect.sqlToQuery(accessor[key].$text)
+
+    expect(query.params).toEqual([])
+    expect(query.sql).toBe(
+      `jsonb_extract_path_text(${sqlString(JSON.stringify({ [key]: 'alias-hit' }))}::jsonb, ${sqlString(key)})`,
+    )
+    await expect(executeQuery(db, accessor[key].$text)).resolves.toBe(
+      'alias-hit',
+    )
+  })
+
+  it('rejects symbol path segments instead of coercing them into SQL', () => {
+    const accessor = jsonAccess(emptyJson) as any
+
+    expect(() => accessor[Symbol.for('json-path')]).toThrow(
+      'Symbols are not supported in JSON paths',
+    )
+  })
+})

--- a/tests/json/sql-injection-array-delete.test.ts
+++ b/tests/json/sql-injection-array-delete.test.ts
@@ -1,0 +1,119 @@
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { arrayDelete } from '../../src/json/index.ts'
+import { jsonArrayDelete } from '../../src/json/operations/array.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+let db: PgliteDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+describe('jsonArrayDelete SQL injection and misuse resistance', () => {
+  const sourceSql = `'["zero","one","two","three"]'::jsonb`
+  const source = sql<string[]>`${sql.raw(sourceSql)}`
+
+  it.each([
+    { index: 0, sqlIndex: '0' },
+    { index: 1, sqlIndex: '1' },
+    { index: 3, sqlIndex: '3' },
+    { index: -1, sqlIndex: '-1' },
+    { index: -3, sqlIndex: '-3' },
+    { index: 2147483647, sqlIndex: '2147483647' },
+    { index: -2147483648, sqlIndex: '-2147483648' },
+  ])('renders numeric index $index as an integer operand', (testCase) => {
+    const query = dialect.sqlToQuery(jsonArrayDelete(source, testCase.index))
+
+    expect(query.params).toEqual([])
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) - ${testCase.sqlIndex}`,
+    )
+  })
+
+  it.each([
+    { index: 0, expected: ['one', 'two', 'three'] },
+    { index: 1, expected: ['zero', 'two', 'three'] },
+    { index: -1, expected: ['zero', 'one', 'two'] },
+    { index: 99, expected: ['zero', 'one', 'two', 'three'] },
+    { index: -99, expected: ['zero', 'one', 'two', 'three'] },
+    { index: 2147483647, expected: ['zero', 'one', 'two', 'three'] },
+    { index: -2147483648, expected: ['zero', 'one', 'two', 'three'] },
+  ])('deletes index $index at runtime without SQL params', async (testCase) => {
+    const result = await executeQuery(
+      db,
+      jsonArrayDelete(source, testCase.index),
+    )
+
+    expect(result).toEqual(testCase.expected)
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    2147483648,
+    -2147483649,
+    Number.MAX_SAFE_INTEGER,
+    Number.MIN_SAFE_INTEGER,
+    1.2,
+    -1.2,
+  ])('lets PostgreSQL reject invalid numeric index %s', async (index) => {
+    await expect(
+      executeQuery(db, jsonArrayDelete(source, index as any)),
+    ).rejects.toThrow()
+  })
+
+  it('keeps string index misuse as PostgreSQL text-delete semantics', async () => {
+    const hostileIndex = "0'); drop table array_delete_sentinel; --"
+    const query = dialect.sqlToQuery(
+      jsonArrayDelete(source, hostileIndex as any),
+    )
+
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) - '0''); drop table array_delete_sentinel; --'`,
+    )
+    expect(query.params).toEqual([])
+    await expect(
+      executeQuery(db, jsonArrayDelete(source, hostileIndex as any)),
+    ).resolves.toEqual(['zero', 'one', 'two', 'three'])
+  })
+
+  it('preserves parameterized source SQL params and deletes by index', async () => {
+    const payload = "source'); drop table array_delete_sentinel; --"
+    const sourceParam = JSON.stringify(['keep', payload])
+    const parameterizedSource = sql<string[]>`${sourceParam}::jsonb`
+    const query = dialect.sqlToQuery(jsonArrayDelete(parameterizedSource, 1))
+
+    expect(query.sql).toBe(
+      `coalesce(nullif($1::jsonb, 'null'::jsonb), '[]'::jsonb) - 1`,
+    )
+    expect(query.params).toEqual([sourceParam])
+    expect(query.sql).not.toContain(payload)
+    await expect(
+      executeQuery(db, jsonArrayDelete(parameterizedSource, 1)),
+    ).resolves.toEqual(['keep'])
+  })
+
+  it('keeps SQLWrapper source expressions caller-controlled while preserving params', () => {
+    const payload = "wrapped'); select 1; --"
+    const wrapperSource = sql<string[]>`'["keep"]'::jsonb || ${JSON.stringify([
+      payload,
+    ])}::jsonb`
+    const query = dialect.sqlToQuery(jsonArrayDelete(wrapperSource, 1))
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('["keep"]'::jsonb || $1::jsonb, 'null'::jsonb), '[]'::jsonb) - 1`,
+    )
+    expect(query.params).toEqual([JSON.stringify([payload])])
+    expect(query.sql).not.toContain(payload)
+  })
+
+  it('public arrayDelete alias generates the same SQL and params as jsonArrayDelete', () => {
+    const directQuery = dialect.sqlToQuery(jsonArrayDelete(source, -1))
+    const aliasQuery = dialect.sqlToQuery(arrayDelete(source, -1))
+
+    expect(aliasQuery).toEqual(directQuery)
+  })
+})

--- a/tests/json/sql-injection-array-push.test.ts
+++ b/tests/json/sql-injection-array-push.test.ts
@@ -1,0 +1,172 @@
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { arrayPush } from '../../src/json/index.ts'
+import { jsonArrayPush } from '../../src/json/operations/array.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+let db: PgliteDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+const jsonParam = (value: unknown) => JSON.stringify(value)
+
+describe('JSON Array Push SQL injection handling', () => {
+  const sourceSql = `'[]'::jsonb`
+  const source = sql<unknown[]>`${sql.raw(sourceSql)}`
+
+  it('keeps malicious string elements parameterized and preserves them at runtime', async () => {
+    await db.execute(
+      sql`create table array_push_sentinel (id integer primary key)`,
+    )
+    await db.execute(sql`insert into array_push_sentinel (id) values (1)`)
+
+    const payloads = [
+      `"}'::jsonb); drop table array_push_sentinel; --`,
+      `value'); select pg_sleep(10); --`,
+      `\\' union select current_user --`,
+      `comment /* break */ close */ ; select 1`,
+    ]
+    const result = jsonArrayPush(source, ...payloads)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual(payloads.map(jsonParam))
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb, $2::jsonb, $3::jsonb, $4::jsonb)`,
+    )
+    for (const payload of payloads) expect(query.sql).not.toContain(payload)
+    await expect(executeQuery(db, result)).resolves.toEqual(payloads)
+
+    const sentinel = await db.execute(
+      sql`select count(*)::int as count from array_push_sentinel`,
+    )
+    expect(sentinel.rows).toEqual([{ count: 1 }])
+  })
+
+  it('keeps malicious object keys and values inside one JSONB parameter', async () => {
+    const key = `key'); drop table array_push_sentinel; --`
+    const nestedKey = `nested'); select pg_sleep(10); --`
+    const valuePayload = `value'); drop table array_push_sentinel; --`
+    const value = {
+      [key]: valuePayload,
+      nested: {
+        [nestedKey]: [valuePayload],
+      },
+      omitted: undefined,
+    } as any
+    const expectedValue = {
+      [key]: valuePayload,
+      nested: {
+        [nestedKey]: [valuePayload],
+      },
+    }
+    const result = jsonArrayPush(source, value)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([jsonParam(value)])
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
+    )
+    expect(query.sql).not.toContain(key)
+    expect(query.sql).not.toContain(nestedKey)
+    expect(query.sql).not.toContain(valuePayload)
+    await expect(executeQuery(db, result)).resolves.toEqual([expectedValue])
+  })
+
+  it('keeps malicious nested arrays as JSON data', async () => {
+    const firstPayload = `array item'); select version(); --`
+    const secondPayload = `nested array item'); drop schema public cascade; --`
+    const pushedArray = [
+      firstPayload,
+      [secondPayload, undefined],
+      { safe: firstPayload },
+    ] as any
+    const expectedArray = [
+      firstPayload,
+      [secondPayload, null],
+      { safe: firstPayload },
+    ]
+    const result = jsonArrayPush(source, pushedArray)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([jsonParam(pushedArray)])
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb)`,
+    )
+    expect(query.sql).not.toContain(firstPayload)
+    expect(query.sql).not.toContain(secondPayload)
+    await expect(executeQuery(db, result)).resolves.toEqual([expectedArray])
+  })
+
+  it('converts pushed undefined and null to JSON null values', async () => {
+    const result = jsonArrayPush(source, undefined, null)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual(['null', 'null'])
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::jsonb, $2::jsonb)`,
+    )
+    await expect(executeQuery(db, result)).resolves.toEqual([null, null])
+  })
+
+  it('preserves SQLWrapper placeholders while treating wrapper SQL as caller-controlled', async () => {
+    const barePayload = `bare'); drop table array_push_sentinel; --`
+    const computedPayload = `computed'); select pg_sleep(10); --`
+    const bareParam = sql<string>`${barePayload}`
+    const typedParam = sql<string>`${barePayload}::text`
+    const computed = sql<
+      Record<string, string>
+    >`jsonb_build_object('safe', ${computedPayload})`
+    const typedComputed = sql<
+      Record<string, string>
+    >`jsonb_build_object('safe', ${computedPayload}::text)`
+    const result = jsonArrayPush(source, bareParam, computed)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([barePayload, computedPayload])
+    expect(query.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1, jsonb_build_object('safe', $2))`,
+    )
+    expect(query.sql).not.toContain(barePayload)
+    expect(query.sql).not.toContain(computedPayload)
+
+    const runtimeResult = jsonArrayPush(source, typedParam, typedComputed)
+    const runtimeQuery = dialect.sqlToQuery(runtimeResult)
+
+    expect(runtimeQuery.params).toEqual([barePayload, computedPayload])
+    expect(runtimeQuery.sql).toBe(
+      `coalesce(nullif(${sourceSql}, 'null'::jsonb), '[]'::jsonb) || jsonb_build_array($1::text, jsonb_build_object('safe', $2::text))`,
+    )
+    await expect(executeQuery(db, runtimeResult)).resolves.toEqual([
+      barePayload,
+      { safe: computedPayload },
+    ])
+  })
+
+  it('documents source SQL misuse while keeping pushed values parameterized', () => {
+    const rawSourceSql = `'[]'::jsonb); select pg_sleep(10); --`
+    const payload = `value'); drop table array_push_sentinel; --`
+    const unsafeSource = sql<unknown[]>`${sql.raw(rawSourceSql)}`
+    const result = jsonArrayPush(unsafeSource, payload)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([jsonParam(payload)])
+    expect(query.sql).toContain(rawSourceSql)
+    expect(query.sql).toContain('pg_sleep')
+    expect(query.sql).not.toContain(payload)
+  })
+
+  it('applies the same value parameterization through public arrayPush alias', async () => {
+    const payload = `alias'); drop table array_push_sentinel; --`
+    const directQuery = dialect.sqlToQuery(jsonArrayPush(source, payload))
+    const aliasResult = arrayPush(source, payload)
+    const aliasQuery = dialect.sqlToQuery(aliasResult)
+
+    expect(aliasQuery).toEqual(directQuery)
+    expect(aliasQuery.params).toEqual([jsonParam(payload)])
+    expect(aliasQuery.sql).not.toContain(payload)
+    await expect(executeQuery(db, aliasResult)).resolves.toEqual([payload])
+  })
+})

--- a/tests/json/sql-injection-array-set.test.ts
+++ b/tests/json/sql-injection-array-set.test.ts
@@ -1,0 +1,195 @@
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { arraySet } from '../../src/json/index.ts'
+import { jsonArraySet } from '../../src/json/operations/array.ts'
+import { jsonBuild } from '../../src/json/operations/build.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+let db: PgliteDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+const arraySql = `'["a", "b"]'::jsonb`
+const baseArray = sql<any[]>`${sql.raw(arraySql)}`
+
+const jsonParam = (value: unknown) => JSON.stringify(value)
+
+const sqlString = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+const stripSqlStringLiterals = (query: string) => {
+  let stripped = ''
+
+  for (let i = 0; i < query.length; i++) {
+    if (query[i] !== "'") {
+      stripped += query[i]
+      continue
+    }
+
+    i++
+    while (i < query.length) {
+      if (query[i] === "'" && query[i + 1] === "'") {
+        i += 2
+        continue
+      }
+      if (query[i] === "'") break
+      i++
+    }
+
+    stripped += "''"
+  }
+
+  return stripped
+}
+
+const expectNoExecutableInjection = (query: string) => {
+  const structuralSql = stripSqlStringLiterals(query).toLowerCase()
+
+  expect(structuralSql).not.toContain('drop table')
+  expect(structuralSql).not.toContain('pg_sleep')
+  expect(structuralSql).not.toContain('select 1')
+}
+
+describe('jsonArraySet SQL injection hardening', () => {
+  const maliciousValue = "x'); select pg_sleep(1); --"
+  const maliciousObjectKey = "k'); drop table users; --"
+  const maliciousObjectValue = "v'); select 1; --"
+
+  it('keeps malicious plain string values parameterized', async () => {
+    const result = jsonArraySet(baseArray, 0, maliciousValue)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
+    )
+    expect(query.sql).not.toContain(maliciousValue)
+    expect(query.params).toEqual([jsonParam(maliciousValue)])
+    expectNoExecutableInjection(query.sql)
+    await expect(executeQuery(db, result)).resolves.toEqual([
+      maliciousValue,
+      'b',
+    ])
+  })
+
+  it('keeps malicious plain object keys and values inside one JSON param', async () => {
+    const value = {
+      [maliciousObjectKey]: maliciousObjectValue,
+      safe: 'ok',
+    }
+    const result = jsonArraySet(baseArray, 0, value)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
+    )
+    expect(query.sql).not.toContain(maliciousObjectKey)
+    expect(query.sql).not.toContain(maliciousObjectValue)
+    expect(query.params).toEqual([jsonParam(value)])
+    expectNoExecutableInjection(query.sql)
+    await expect(executeQuery(db, result)).resolves.toEqual([value, 'b'])
+  })
+
+  it('escapes malicious jsonBuild object keys and parameterizes values', async () => {
+    const value = jsonBuild({
+      [maliciousObjectKey]: maliciousObjectValue,
+      skip: undefined,
+    } as any)
+    const result = jsonArraySet(baseArray, 0, value)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', to_jsonb(jsonb_build_object(${sqlString(maliciousObjectKey)}, $1::jsonb)), false)`,
+    )
+    expect(query.sql).not.toContain('skip')
+    expect(query.sql).not.toContain(maliciousObjectValue)
+    expect(query.params).toEqual([jsonParam(maliciousObjectValue)])
+    expectNoExecutableInjection(query.sql)
+    await expect(executeQuery(db, result)).resolves.toEqual([
+      { [maliciousObjectKey]: maliciousObjectValue },
+      'b',
+    ])
+  })
+
+  it('maps undefined and null values to JSON null params', async () => {
+    const undefinedResult = jsonArraySet(baseArray, 0, undefined as any)
+    const nullResult = jsonArraySet(baseArray, 1, null as any)
+    const undefinedQuery = dialect.sqlToQuery(undefinedResult)
+    const nullQuery = dialect.sqlToQuery(nullResult)
+
+    expect(undefinedQuery.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1::jsonb, false)`,
+    )
+    expect(nullQuery.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1::jsonb, false)`,
+    )
+    expect(undefinedQuery.params).toEqual(['null'])
+    expect(nullQuery.params).toEqual(['null'])
+    await expect(executeQuery(db, undefinedResult)).resolves.toEqual([
+      null,
+      'b',
+    ])
+    await expect(executeQuery(db, nullResult)).resolves.toEqual(['a', null])
+  })
+
+  it('keeps bare SQLWrapper params parameterized', () => {
+    const result = jsonArraySet(baseArray, 0, sql`${maliciousValue}`)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', $1, false)`,
+    )
+    expect(query.sql).not.toContain(maliciousValue)
+    expect(query.params).toEqual([maliciousValue])
+    expectNoExecutableInjection(query.sql)
+  })
+
+  it('embeds computed SQLWrapper values as intentional SQL with params', async () => {
+    const result = jsonArraySet(baseArray, 0, sql`lower(${maliciousValue})`)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{0}', to_jsonb(lower($1)), false)`,
+    )
+    expect(query.sql).not.toContain(maliciousValue)
+    expect(query.params).toEqual([maliciousValue])
+    expectNoExecutableInjection(query.sql)
+    await expect(executeQuery(db, result)).resolves.toEqual([
+      maliciousValue.toLowerCase(),
+      'b',
+    ])
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    2147483648,
+    -2147483649,
+    Number.MAX_SAFE_INTEGER,
+    Number.MIN_SAFE_INTEGER,
+    1.2,
+    -1.2,
+  ])('lets PostgreSQL reject invalid index %s', async (index) => {
+    await expect(
+      executeQuery(db, jsonArraySet(baseArray, index as any, 'safe')),
+    ).rejects.toThrow()
+  })
+
+  it('applies same value escaping through public arraySet alias', async () => {
+    const result = arraySet(baseArray, 1, maliciousValue)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(coalesce(nullif(${arraySql}, 'null'::jsonb), '[]'::jsonb), '{1}', $1::jsonb, false)`,
+    )
+    expect(query.sql).not.toContain(maliciousValue)
+    expect(query.params).toEqual([jsonParam(maliciousValue)])
+    expectNoExecutableInjection(query.sql)
+    await expect(executeQuery(db, result)).resolves.toEqual([
+      'a',
+      maliciousValue,
+    ])
+  })
+})

--- a/tests/json/sql-injection-build.test.ts
+++ b/tests/json/sql-injection-build.test.ts
@@ -1,0 +1,141 @@
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { build } from '../../src/json/index.ts'
+import { jsonBuild } from '../../src/json/operations/build.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+let db: PgliteDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+const jsonParam = (value: unknown) => JSON.stringify(value)
+
+const sqlString = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+describe('JSON Build SQL injection handling', () => {
+  it('keeps malicious primitive strings parameterized', async () => {
+    const payloads = [
+      `"}'::jsonb); select pg_sleep(99); --`,
+      `value'); drop table users; --`,
+      `\\' union select current_user --`,
+      `comment /* break */ close */ ; select 1`,
+    ]
+
+    for (const payload of payloads) {
+      const query = dialect.sqlToQuery(jsonBuild(payload))
+
+      expect(query.sql).toBe('$1::jsonb')
+      expect(query.sql).not.toContain(payload)
+      expect(query.params).toEqual([jsonParam(payload)])
+      await expect(executeQuery(db, jsonBuild(payload))).resolves.toBe(payload)
+    }
+  })
+
+  it('escapes malicious object keys as SQL string literals and preserves them at runtime', async () => {
+    const selectKey = `name'); select pg_sleep(99); --`
+    const commaKey = `jsonb_build_object('pwned', true), 'safe`
+    const pathKey = `profile'} || '{"admin":true}'::jsonb || '{"profile`
+    const nestedKey = `nested'); drop schema public cascade; --`
+    const value = {
+      [selectKey]: 'kept',
+      [commaKey]: 7,
+      [pathKey]: {
+        [nestedKey]: false,
+      },
+    }
+
+    const query = dialect.sqlToQuery(jsonBuild(value))
+
+    expect(query.params).toEqual([
+      jsonParam('kept'),
+      jsonParam(7),
+      jsonParam(false),
+    ])
+    expect(query.sql).toContain(sqlString(selectKey))
+    expect(query.sql).toContain(sqlString(commaKey))
+    expect(query.sql).toContain(sqlString(pathKey))
+    expect(query.sql).toContain(sqlString(nestedKey))
+    await expect(executeQuery(db, jsonBuild(value))).resolves.toEqual(value)
+  })
+
+  it('keeps nested malicious values parameterized through objects and arrays', async () => {
+    const valuePayload = `"}; drop schema public cascade; --`
+    const secondPayload = `array item'); select version(); --`
+    const keyPayload = `items'); select current_database(); --`
+    const nestedPayload = `last value' /* not SQL */ --`
+    const value = {
+      plain: valuePayload,
+      keep: [
+        'prefix',
+        secondPayload,
+        undefined,
+        { [keyPayload]: nestedPayload },
+      ],
+      skip: undefined,
+    } as any
+
+    const query = dialect.sqlToQuery(jsonBuild(value))
+
+    expect(query.params).toEqual([
+      jsonParam(valuePayload),
+      jsonParam('prefix'),
+      jsonParam(secondPayload),
+      jsonParam(null),
+      jsonParam(nestedPayload),
+    ])
+    expect(query.sql).not.toContain(valuePayload)
+    expect(query.sql).not.toContain(secondPayload)
+    expect(query.sql).not.toContain(nestedPayload)
+    expect(query.sql).not.toContain('skip')
+    expect(query.sql).toContain(sqlString(keyPayload))
+    await expect(executeQuery(db, jsonBuild(value))).resolves.toEqual({
+      plain: valuePayload,
+      keep: ['prefix', secondPayload, null, { [keyPayload]: nestedPayload }],
+    })
+  })
+
+  it('preserves SQLWrapper params while treating raw SQL as caller-controlled SQL', async () => {
+    const barePayload = `bare'); select pg_sleep(99); --`
+    const bareParam = sql<string>`${barePayload}`
+    const computed = sql<string>`lower(${'MIXED'})`
+    const trustedRawJson = sql.raw(`'{"trusted":true}'::jsonb`)
+
+    const bareQuery = dialect.sqlToQuery(jsonBuild({ safe: bareParam }))
+    const computedQuery = dialect.sqlToQuery(jsonBuild({ computed }))
+    const rawQuery = dialect.sqlToQuery(jsonBuild(trustedRawJson))
+
+    expect(bareQuery.sql).toBe(`jsonb_build_object('safe', $1)`)
+    expect(bareQuery.params).toEqual([barePayload])
+    expect(computedQuery.sql).toBe(
+      `jsonb_build_object('computed', to_jsonb(lower($1)))`,
+    )
+    expect(computedQuery.params).toEqual(['MIXED'])
+    expect(rawQuery.sql).toBe(`to_jsonb('{"trusted":true}'::jsonb)`)
+    expect(rawQuery.params).toEqual([])
+    await expect(
+      executeQuery(db, jsonBuild({ computed, trustedRawJson })),
+    ).resolves.toEqual({
+      computed: 'mixed',
+      trustedRawJson: { trusted: true },
+    })
+  })
+
+  it('applies the same escaping and runtime behavior through the public build alias', async () => {
+    const key = `alias'); select pg_sleep(99); --`
+    const payload = `alias value'); drop table test; --`
+    const value = {
+      [key]: payload,
+      nested: [payload],
+    }
+
+    const query = dialect.sqlToQuery(build(value))
+
+    expect(query.params).toEqual([jsonParam(payload), jsonParam(payload)])
+    expect(query.sql).toContain(sqlString(key))
+    expect(query.sql).not.toContain(payload)
+    await expect(executeQuery(db, build(value))).resolves.toEqual(value)
+  })
+})

--- a/tests/json/sql-injection-coalesce.test.ts
+++ b/tests/json/sql-injection-coalesce.test.ts
@@ -1,0 +1,139 @@
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { coalesce } from '../../src/json/index.ts'
+import { jsonCoalesce } from '../../src/json/operations/coalesce.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+describe('JSON Coalesce SQL injection handling', () => {
+  let db: PgliteDatabase
+
+  beforeAll(async () => {
+    db = await createDatabase()
+  })
+
+  const jsonNull = sql<null>`'null'::jsonb`
+
+  it('keeps malicious string fallbacks in a jsonb parameter', async () => {
+    const fallback = `x'::jsonb); drop table users; select pg_sleep(10); --`
+    const result = jsonCoalesce(jsonNull, fallback)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('null'::jsonb, 'null'::jsonb), $1::jsonb)`,
+    )
+    expect(query.params).toEqual([JSON.stringify(fallback)])
+    expect(await executeQuery(db, result)).toBe(fallback)
+  })
+
+  it('uses the same safe fallback path for SQL NULL sources', async () => {
+    const fallback = `sql-null'); drop table users; --`
+    const result = jsonCoalesce(sql<null>`NULL::jsonb`, fallback)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif(NULL::jsonb, 'null'::jsonb), $1::jsonb)`,
+    )
+    expect(query.params).toEqual([JSON.stringify(fallback)])
+    expect(await executeQuery(db, result)).toBe(fallback)
+  })
+
+  it('escapes malicious object keys and parameterizes object values', async () => {
+    const maliciousKey = `name'); drop table users; --`
+    const nestedKey = `child'); delete from audit; --`
+    const maliciousValue = `value'); select pg_sleep(10); --`
+    const fallback = {
+      [maliciousKey]: maliciousValue,
+      nested: {
+        [nestedKey]: true,
+      },
+    }
+    const result = jsonCoalesce(jsonNull, fallback)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('null'::jsonb, 'null'::jsonb), jsonb_build_object('name''); drop table users; --', $1::jsonb,'nested', jsonb_build_object('child''); delete from audit; --', $2::jsonb)))`,
+    )
+    expect(query.params).toEqual([
+      JSON.stringify(maliciousValue),
+      JSON.stringify(true),
+    ])
+    expect(await executeQuery(db, result)).toEqual(fallback)
+  })
+
+  it('parameterizes malicious array fallback values', async () => {
+    const objectKey = `arr-key'); vacuum; --`
+    const objectValue = `arr-value'); reindex database postgres; --`
+    const fallback = [
+      `zero'); drop schema public cascade; --`,
+      {
+        [objectKey]: objectValue,
+      },
+      null,
+    ]
+    const result = jsonCoalesce(jsonNull, fallback)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('null'::jsonb, 'null'::jsonb), jsonb_build_array($1::jsonb,jsonb_build_object('arr-key''); vacuum; --', $2::jsonb),$3::jsonb))`,
+    )
+    expect(query.params).toEqual([
+      JSON.stringify(fallback[0]),
+      JSON.stringify((fallback[1] as Record<string, string>)[objectKey]),
+      JSON.stringify(null),
+    ])
+    expect(await executeQuery(db, result)).toEqual(fallback)
+  })
+
+  it('treats interpolated source payloads as values, not SQL text', async () => {
+    const sourcePayload = `source'); drop table users; --`
+    const fallback = `fallback'); drop table users; --`
+    const source = sql<string>`${JSON.stringify(sourcePayload)}::jsonb`
+    const result = jsonCoalesce(source, fallback)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif($1::jsonb, 'null'::jsonb), $2::jsonb)`,
+    )
+    expect(query.params).toEqual([
+      JSON.stringify(sourcePayload),
+      JSON.stringify(fallback),
+    ])
+    expect(await executeQuery(db, result)).toBe(sourcePayload)
+  })
+
+  it('documents SQLWrapper fallback trust boundary while converting safe expressions', async () => {
+    const result = jsonCoalesce(jsonNull, sql<number>`42::integer`)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('null'::jsonb, 'null'::jsonb), to_jsonb(42::integer))`,
+    )
+    expect(query.params).toEqual([])
+    expect(await executeQuery(db, result)).toBe(42)
+  })
+
+  it('keeps SQLWrapper fallback parameters bound inside to_jsonb', async () => {
+    const fallback = `wrapped'); drop table users; --`
+    const result = jsonCoalesce(jsonNull, sql<string>`${fallback}::text`)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('null'::jsonb, 'null'::jsonb), to_jsonb($1::text))`,
+    )
+    expect(query.params).toEqual([fallback])
+    expect(await executeQuery(db, result)).toBe(fallback)
+  })
+
+  it('uses same parameterization through public coalesce alias', async () => {
+    const fallback = `alias'); drop table users; --`
+    const result = coalesce(jsonNull, fallback)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `coalesce(nullif('null'::jsonb, 'null'::jsonb), $1::jsonb)`,
+    )
+    expect(query.params).toEqual([JSON.stringify(fallback)])
+    expect(await executeQuery(db, result)).toBe(fallback)
+  })
+})

--- a/tests/json/sql-injection-merge.test.ts
+++ b/tests/json/sql-injection-merge.test.ts
@@ -1,0 +1,137 @@
+import { sql } from 'drizzle-orm'
+import type { PgliteDatabase } from 'drizzle-orm/pglite'
+import { beforeAll, describe, expect, it } from 'vitest'
+import * as json from '../../src/json/index.ts'
+import { jsonBuild } from '../../src/json/operations/build.ts'
+import { jsonMerge } from '../../src/json/operations/merge.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+let db: PgliteDatabase
+
+beforeAll(async () => {
+  db = await createDatabase()
+})
+
+describe('JSON Merge SQL injection and misuse resistance', () => {
+  it('keeps malicious merge values parameterized when operands are built JSON', () => {
+    const maliciousKey = `x'); drop table merge_sentinel; --`
+    const maliciousValue = `value'); drop table merge_sentinel; --`
+    const base = jsonBuild({ stable: 'base' })
+    const mergeObject = Object.create(null) as Record<string, unknown>
+    mergeObject[maliciousKey] = maliciousValue
+
+    const result = jsonMerge(base, jsonBuild(mergeObject))
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([
+      JSON.stringify('base'),
+      JSON.stringify(maliciousValue),
+    ])
+    expect(query.sql).toBe(
+      `coalesce(jsonb_build_object('stable', $1::jsonb), 'null'::jsonb) || coalesce(jsonb_build_object('x''); drop table merge_sentinel; --', $2::jsonb), 'null'::jsonb)`,
+    )
+    expect(query.sql).not.toContain(maliciousValue)
+  })
+
+  it('keeps nested malicious values and array values parameterized through merge', () => {
+    const nestedKey = `nested'); select pg_sleep(10); --`
+    const nestedValue = `nested-value'); drop table merge_sentinel; --`
+    const arrayValue = `array-value'); drop table merge_sentinel; --`
+    const nestedObject = Object.create(null) as Record<string, unknown>
+    nestedObject[nestedKey] = nestedValue
+
+    const result = jsonMerge(
+      jsonBuild({ stable: true }),
+      jsonBuild({
+        payload: nestedObject,
+        values: [arrayValue, sql<string>`${'wrapped value'}`],
+      }),
+    )
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([
+      JSON.stringify(true),
+      JSON.stringify(nestedValue),
+      JSON.stringify(arrayValue),
+      'wrapped value',
+    ])
+    expect(query.sql).toBe(
+      `coalesce(jsonb_build_object('stable', $1::jsonb), 'null'::jsonb) || coalesce(jsonb_build_object('payload', jsonb_build_object('nested''); select pg_sleep(10); --', $2::jsonb),'values', jsonb_build_array($3::jsonb,$4)), 'null'::jsonb)`,
+    )
+    expect(query.sql).not.toContain(nestedValue)
+    expect(query.sql).not.toContain(arrayValue)
+  })
+
+  it('preserves SQLWrapper placeholders and params inside merge coalesce wrappers', () => {
+    const leftValue = `left'); drop table merge_sentinel; --`
+    const rightValue = `right'); drop table merge_sentinel; --`
+    const left = sql`jsonb_build_object('left', ${leftValue})`
+    const right = sql`jsonb_build_object('right', ${rightValue})`
+
+    const result = jsonMerge(left, right)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([leftValue, rightValue])
+    expect(query.sql).toBe(
+      `coalesce(jsonb_build_object('left', $1), 'null'::jsonb) || coalesce(jsonb_build_object('right', $2), 'null'::jsonb)`,
+    )
+    expect(query.sql).not.toContain(leftValue)
+    expect(query.sql).not.toContain(rightValue)
+  })
+
+  it('public merge alias generates the same SQL and params as jsonMerge', () => {
+    const left = jsonBuild({ stable: 'base' })
+    const right = jsonBuild({
+      merged: `alias'); drop table merge_sentinel; --`,
+    })
+
+    const directQuery = dialect.sqlToQuery(jsonMerge(left, right))
+    const aliasQuery = dialect.sqlToQuery(json.merge(left, right))
+
+    expect(aliasQuery).toEqual(directQuery)
+  })
+
+  it('treats prototype-ish names as JSON keys when merging built operands', async () => {
+    const right = Object.create(null) as Record<string, unknown>
+    right.__proto__ = 'proto-value'
+    right.constructor = 'constructor-value'
+    right.prototype = 'prototype-value'
+
+    const result = await executeQuery(
+      db,
+      jsonMerge(jsonBuild({}), jsonBuild(right)),
+    )
+
+    expect(Object.keys(result).sort()).toEqual([
+      '__proto__',
+      'constructor',
+      'prototype',
+    ])
+    expect(Object.hasOwn(result, '__proto__')).toBe(true)
+    expect(result.__proto__).toBe('proto-value')
+    expect(result.constructor).toBe('constructor-value')
+    expect(result.prototype).toBe('prototype-value')
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+  })
+
+  it('preserves malicious merge data at runtime without executing it', async () => {
+    await db.execute(sql`create table merge_sentinel (id integer primary key)`)
+    await db.execute(sql`insert into merge_sentinel (id) values (1)`)
+
+    const maliciousKey = `key'); drop table merge_sentinel; --`
+    const maliciousValue = `value'); drop table merge_sentinel; --`
+    const right = Object.create(null) as Record<string, unknown>
+    right[maliciousKey] = maliciousValue
+
+    const result = await executeQuery(
+      db,
+      jsonMerge(jsonBuild({ safe: true }), jsonBuild(right)),
+    )
+    const sentinel = await db.execute(
+      sql`select count(*)::int as count from merge_sentinel`,
+    )
+
+    expect(result).toEqual({ safe: true, [maliciousKey]: maliciousValue })
+    expect(sentinel.rows).toEqual([{ count: 1 }])
+  })
+})

--- a/tests/json/sql-injection-set-pipe.test.ts
+++ b/tests/json/sql-injection-set-pipe.test.ts
@@ -1,0 +1,183 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { setPipe } from '../../src/json/index.ts'
+import { jsonSetPipe } from '../../src/json/operations/set.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+const quotedSqlString = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+const stripSqlStringLiterals = (query: string) => {
+  let stripped = ''
+
+  for (let i = 0; i < query.length; i++) {
+    if (query[i] !== "'") {
+      stripped += query[i]
+      continue
+    }
+
+    i++
+    while (i < query.length) {
+      if (query[i] === "'" && query[i + 1] === "'") {
+        i += 2
+        continue
+      }
+      if (query[i] === "'") break
+      i++
+    }
+
+    stripped += "''"
+  }
+
+  return stripped
+}
+
+const expectNoExecutableInjection = (query: string) => {
+  const structuralSql = stripSqlStringLiterals(query).toLowerCase()
+
+  expect(structuralSql).not.toContain('drop table')
+  expect(structuralSql).not.toContain('pg_sleep')
+  expect(structuralSql).not.toContain('select 1')
+}
+
+describe('jsonSetPipe SQL injection hardening', () => {
+  const baseValue = sql<Record<string, any>>`'{}'::jsonb`
+  const pathOne = "profile'::text]); select pg_sleep(1); --"
+  const pathTwo = "avatar\\'); drop table users; --"
+  const pathThree = '0); select 1; --'
+  const defaultPath = "config'); select 1; --"
+  const maliciousValue = "x'); select pg_sleep(1); --"
+  const maliciousDefault = "d'); drop table users; --"
+  const maliciousObjectKey = "k'); drop table users; --"
+
+  it('quotes chained malicious path segments as JSON path values', () => {
+    const result = jsonSetPipe(baseValue, (setter) =>
+      (setter as any)[pathOne][pathTwo][pathThree].$set('safe-value'),
+    )
+
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([JSON.stringify('safe-value')])
+    expect(query.sql).toContain('jsonb_set')
+    expect(query.sql).toContain(
+      `array[${quotedSqlString(pathOne)},${quotedSqlString(pathTwo)},${quotedSqlString(pathThree)}]::text[]`,
+    )
+    expectNoExecutableInjection(query.sql)
+  })
+
+  it('keeps malicious alias values and defaults in params', () => {
+    const result = setPipe(baseValue, (setter) =>
+      (setter as any)[defaultPath]
+        .$default({ [maliciousObjectKey]: maliciousDefault })
+        [maliciousObjectKey].$set(maliciousValue),
+    )
+
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([
+      JSON.stringify(maliciousDefault),
+      JSON.stringify(maliciousValue),
+    ])
+    expect(query.sql).toContain(
+      `jsonb_build_object(${quotedSqlString(maliciousObjectKey)}, $1::jsonb)`,
+    )
+    expect(query.sql).toContain(
+      `jsonb_extract_path('{}'::jsonb, ${quotedSqlString(defaultPath)})`,
+    )
+    expect(query.sql).toContain(
+      `array[${quotedSqlString(defaultPath)},${quotedSqlString(maliciousObjectKey)}]::text[]`,
+    )
+    expect(query.sql).not.toContain(maliciousDefault)
+    expect(query.sql).not.toContain(maliciousValue)
+    expectNoExecutableInjection(query.sql)
+  })
+
+  it('coerces createMissing SQLWrapper misuse to boolean before SQL generation', () => {
+    const rawCreateMissing = sql.raw('true); drop table users; --')
+
+    const setQuery = dialect.sqlToQuery(
+      jsonSetPipe(baseValue, (setter) =>
+        (setter as any).field.$set('safe-value', rawCreateMissing),
+      ),
+    )
+    const defaultQuery = dialect.sqlToQuery(
+      jsonSetPipe(baseValue, (setter) =>
+        (setter as any).field
+          .$default('safe-value', 0 as any)
+          .leaf.$set('safe'),
+      ),
+    )
+
+    expect(setQuery.sql).toBe(
+      `jsonb_set('{}'::jsonb, array['field']::text[], $1::jsonb, true)`,
+    )
+    expect(setQuery.params).toEqual([JSON.stringify('safe-value')])
+    expect(defaultQuery.sql).toBe(
+      `jsonb_set(jsonb_set(coalesce(nullif('{}'::jsonb, 'null'::jsonb), '{}'::jsonb), array['field']::text[], coalesce(nullif(jsonb_extract_path('{}'::jsonb, 'field'), 'null'::jsonb), $1::jsonb), false), array['field','leaf']::text[], $2::jsonb, true)`,
+    )
+    expect(defaultQuery.params).toEqual([
+      JSON.stringify('safe-value'),
+      JSON.stringify('safe'),
+    ])
+    expect(setQuery.sql).not.toContain('drop table')
+    expect(defaultQuery.sql).not.toContain('drop table')
+  })
+
+  it('keeps SQLWrapper values parameterized across multiple operations', () => {
+    const wrapperValue = "wrapped'); select pg_sleep(1); --"
+    const result = jsonSetPipe(
+      baseValue,
+      (setter) => (setter as any).bare.$set(sql`${wrapperValue}`),
+      (setter) => (setter as any).expr.$set(sql`lower(${wrapperValue})`),
+    )
+
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.params).toEqual([wrapperValue, wrapperValue])
+    expect(query.sql).toBe(
+      "jsonb_set(jsonb_set('{}'::jsonb, array['bare']::text[], $1, true), array['expr']::text[], to_jsonb(lower($2)), true)",
+    )
+    expect(query.sql).not.toContain(wrapperValue)
+    expectNoExecutableInjection(query.sql)
+  })
+
+  it('executes malicious paths, values, defaults, and SQLWrapper expressions as data', async () => {
+    const db = await createDatabase()
+    const sqlWrapperValue = "MIXED'); SELECT pg_sleep(1); --"
+    const source = sql<Record<string, any>>`${JSON.stringify({
+      [pathOne]: {
+        [pathTwo]: {
+          [pathThree]: 'old',
+        },
+      },
+      keep: true,
+    })}::jsonb`
+
+    const result = await executeQuery(
+      db,
+      jsonSetPipe(
+        source,
+        (setter) =>
+          (setter as any)[pathOne][pathTwo][pathThree].$set(maliciousValue),
+        (setter) =>
+          (setter as any)[defaultPath]
+            .$default({ [maliciousObjectKey]: maliciousDefault })
+            [maliciousObjectKey].$set('overridden'),
+        (setter) =>
+          (setter as any).computed.$set(sql`lower(${sqlWrapperValue})`),
+      ),
+    )
+
+    expect(result).toEqual({
+      [pathOne]: {
+        [pathTwo]: {
+          [pathThree]: maliciousValue,
+        },
+      },
+      keep: true,
+      [defaultPath]: {
+        [maliciousObjectKey]: 'overridden',
+      },
+      computed: sqlWrapperValue.toLowerCase(),
+    })
+  }, 15_000)
+})

--- a/tests/json/sql-injection-set.test.ts
+++ b/tests/json/sql-injection-set.test.ts
@@ -1,0 +1,198 @@
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { set as jsonSetAlias } from '../../src/json/index.ts'
+import { jsonSet } from '../../src/json/operations/set.ts'
+import { createDatabase, dialect, executeQuery } from '../utils.ts'
+
+describe('JSON Set SQL injection hardening', () => {
+  const sourceSql = `'{}'::jsonb`
+  const source = sql<Record<string, unknown>>`${sql.raw(sourceSql)}`
+
+  it('keeps malicious path components inside escaped text array literals', () => {
+    const result =
+      jsonSet(source)["x'), true); drop table users; --"].nested['a,b{c}'].$set(
+        "v'); select 1; --",
+      )
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(${sourceSql}, array['x''), true); drop table users; --','nested','a,b{c}']::text[], $1::jsonb, true)`,
+    )
+    expect(query.params).toEqual([JSON.stringify("v'); select 1; --")])
+  })
+
+  it('keeps malicious object keys inside jsonb_build_object key literals', () => {
+    const key = "k'); drop table audit; --"
+    const result = jsonSet(source).payload.$set({
+      [key]: "v'); select 1; --",
+      safe: 'ok',
+    })
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(${sourceSql}, array['payload']::text[], jsonb_build_object('k''); drop table audit; --', $1::jsonb,'safe', $2::jsonb), true)`,
+    )
+    expect(query.params).toEqual([
+      JSON.stringify("v'); select 1; --"),
+      JSON.stringify('ok'),
+    ])
+  })
+
+  it('keeps $default path and value inputs escaped or parameterized', () => {
+    const defaultKey = "d'); drop table d; --"
+    const result = jsonSet(source)
+      ["cfg'); drop table cfg; --"].$default({
+        [defaultKey]: "default'); --",
+      })
+      ["leaf'); drop table l; --"].$set("final'); --", false)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(jsonb_set(coalesce(nullif(${sourceSql}, 'null'::jsonb), '{}'::jsonb), array['cfg''); drop table cfg; --']::text[], coalesce(nullif(jsonb_extract_path(${sourceSql}, 'cfg''); drop table cfg; --'), 'null'::jsonb), jsonb_build_object('d''); drop table d; --', $1::jsonb)), true), array['cfg''); drop table cfg; --','leaf''); drop table l; --']::text[], $2::jsonb, false)`,
+    )
+    expect(query.params).toEqual([
+      JSON.stringify("default'); --"),
+      JSON.stringify("final'); --"),
+    ])
+  })
+
+  it('coerces createMissing SQLWrapper misuse to boolean before SQL generation', () => {
+    const rawCreateMissing = sql.raw('true); drop table users; --')
+
+    const setQuery = dialect.sqlToQuery(
+      jsonSet(source).payload.$set('safe', rawCreateMissing as any),
+    )
+    const defaultQuery = dialect.sqlToQuery(
+      jsonSet(source)
+        .payload.$default('safe', 0 as any)
+        .leaf.$set('safe'),
+    )
+
+    expect(setQuery.sql).toBe(
+      `jsonb_set(${sourceSql}, array['payload']::text[], $1::jsonb, true)`,
+    )
+    expect(setQuery.params).toEqual([JSON.stringify('safe')])
+    expect(defaultQuery.sql).toBe(
+      `jsonb_set(jsonb_set(coalesce(nullif(${sourceSql}, 'null'::jsonb), '{}'::jsonb), array['payload']::text[], coalesce(nullif(jsonb_extract_path(${sourceSql}, 'payload'), 'null'::jsonb), $1::jsonb), false), array['payload','leaf']::text[], $2::jsonb, true)`,
+    )
+    expect(defaultQuery.params).toEqual([
+      JSON.stringify('safe'),
+      JSON.stringify('safe'),
+    ])
+    expect(setQuery.sql).not.toContain('drop table')
+    expect(defaultQuery.sql).not.toContain('drop table')
+  })
+
+  it('treats plain malicious string values as JSON params, not SQL', () => {
+    const result = jsonSet(source).payload.$set("'}::jsonb); select 1; --")
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(${sourceSql}, array['payload']::text[], $1::jsonb, true)`,
+    )
+    expect(query.params).toEqual([JSON.stringify("'}::jsonb); select 1; --")])
+  })
+
+  it('keeps bare SQLWrapper params parameterized', () => {
+    const result = jsonSet(source).payload.$set(sql`${"x'); select 1; --"}`)
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(${sourceSql}, array['payload']::text[], $1, true)`,
+    )
+    expect(query.params).toEqual(["x'); select 1; --"])
+  })
+
+  it('embeds non-bare SQLWrapper values as intentional SQL expressions', () => {
+    const result = jsonSet(source).payload.$set(
+      sql`jsonb_build_object('safe', ${'x'}::text)`,
+    )
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(${sourceSql}, array['payload']::text[], to_jsonb(jsonb_build_object('safe', $1::text)), true)`,
+    )
+    expect(query.params).toEqual(['x'])
+  })
+
+  it('public set alias has same escaping behavior as jsonSet', () => {
+    const result =
+      jsonSetAlias(source)["alias'); drop table alias; --"].$set('ok')
+    const query = dialect.sqlToQuery(result)
+
+    expect(query.sql).toBe(
+      `jsonb_set(${sourceSql}, array['alias''); drop table alias; --']::text[], $1::jsonb, true)`,
+    )
+    expect(query.params).toEqual([JSON.stringify('ok')])
+  })
+
+  it('rejects root-level $set and $default misuse', () => {
+    expect(() => jsonSet(source).$set({})).toThrow(
+      'Cannot set default value at root level',
+    )
+    expect(() => jsonSet(source).$default({})).toThrow(
+      'Cannot set default value at root level',
+    )
+  })
+
+  it('updates exact malicious path keys at runtime', async () => {
+    const db = await createDatabase()
+    const key = "x'), true); drop table users; --"
+    const leaf = 'a,b{c}'
+    const runtimeSource = sql<
+      Record<string, { [key: string]: string }>
+    >`'{"x''), true); drop table users; --": {"a,b{c}": "old"}}'::jsonb`
+
+    const result = await executeQuery(
+      db,
+      jsonSet(runtimeSource)[key][leaf].$set("v'); select 1; --"),
+    )
+
+    expect(result).toEqual({
+      [key]: {
+        [leaf]: "v'); select 1; --",
+      },
+    })
+  }, 15_000)
+
+  it('writes malicious object keys and values as JSON data at runtime', async () => {
+    const db = await createDatabase()
+    const key = "k'); drop table audit; --"
+
+    const result = await executeQuery(
+      db,
+      jsonSet(source).payload.$set({
+        [key]: "v'); select 1; --",
+      }),
+    )
+
+    expect(result).toEqual({
+      payload: {
+        [key]: "v'); select 1; --",
+      },
+    })
+  })
+
+  it('applies $default to exact malicious keys at runtime', async () => {
+    const db = await createDatabase()
+    const key = "cfg'); drop table cfg; --"
+    const defaultKey = "d'); drop table d; --"
+    const leaf = "leaf'); drop table l; --"
+
+    const result = await executeQuery(
+      db,
+      jsonSet(source)
+        [key].$default({
+          [defaultKey]: "default'); --",
+        })
+        [leaf].$set("final'); --"),
+    )
+
+    expect(result).toEqual({
+      [key]: {
+        [defaultKey]: "default'); --",
+        [leaf]: "final'); --",
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add focused SQL injection and misuse coverage for JSON helpers.
- Cover access, build, coalesce, merge, set, setPipe, arrayPush, arraySet, and arrayDelete.
- Exercise hostile keys, values, paths, SQLWrapper trust boundaries, aliases, and runtime behavior where useful.

## Validation

- pnpm exec vitest run tests/json/sql-injection-*.test.ts --reporter=dot
- pnpm exec vitest run tests/json/access.test.ts tests/json/array.test.ts tests/json/build.test.ts tests/json/common.test.ts tests/json/merge.test.ts tests/json/set.test.ts tests/json/integration.test.ts tests/json/sql-injection-*.test.ts --reporter=dot
- pnpm run check:type
- pnpm exec biome check tests/json/sql-injection-*.test.ts
